### PR TITLE
Translate Japanese content to English (fix #1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ GitHub Issues → issue-manager → workers → issue-manager → GitHub PRs
 
 #### 2️⃣ Environment Setup
 ```bash
-./claude/setup.sh          # デフォルト: 3 workers
+./claude/setup.sh          # Default: 3 workers
 
 # Specify number of workers
 ./claude/setup.sh 5        # 5 workers
@@ -301,7 +301,7 @@ rm -rf ./claude
 
 ### How to Send Messages
 ```bash
-./claude/agent-send.sh [相手の名前] "[メッセージ]"
+./claude/agent-send.sh [recipient name] "[message]"
 
 # Example: Send to Issue Manager
 ./claude/agent-send.sh issue-manager "Please check GitHub Issues"
@@ -314,7 +314,7 @@ rm -rf ./claude
 
 **Issue Manager → Worker：**
 ```
-あなたはworker1です。
+You are worker1.
 
 【GitHub Issue Assignment】
 Issue #123: Add dark mode toggle feature
@@ -346,7 +346,7 @@ Please report progress or questions as needed.
 
 **Worker → Issue Manager：**
 ```
-【Issue #123 完了報告】Worker1
+【Issue #123 Completion Report】Worker1
 
 ## Implementation
 - Added dark mode toggle button

--- a/README_ja.md
+++ b/README_ja.md
@@ -1,23 +1,23 @@
 # 🤖 Claude Code GitHub Issue Management
 
-GitHub Issueを自動管理する、AI駆動の開発ワークフローシステムです。
+An AI-driven development workflow system for automated GitHub Issue management.
 
-[Claude Code エージェント通信システム](https://github.com/Akira-Papa/Claude-Code-Communication)にヒントを得て、もともと手元でやっていたGitHub Issueを作ってそれをClaude Codeに解決してもらうやり方をAI Workerで実行できるようにしました。
+Inspired by the [Claude Code Agent Communication System](https://github.com/Akira-Papa/Claude-Code-Communication), this system takes the approach of creating GitHub Issues locally and having Claude Code resolve them, now enabling AI Workers to execute this workflow.
 
 ## Demo
 
 ![](demo.gif)
 
-**機能**
-1. GitHub Issueを自動監視・管理するAI Issue Managerと複数のWorkerが協力（デフォルト3、setup.shで指定可能）
-2. IssueがオープンされるとWorkerに自動アサイン、解決後に自動PR作成
-3. 完全自動化されたGitHub Issue → PR → マージのワークフロー
+**Features**
+1. AI Issue Manager and multiple Workers collaborate for automated GitHub Issue monitoring and management (default 3, configurable in setup.sh)
+2. Automatic Worker assignment when Issues are opened, and automatic PR creation after resolution
+3. Fully automated GitHub Issue → PR → Merge workflow
 
-**システムの特徴：**
-- 🔄 GitHub Issue自動監視・アサイン
-- 🚀 Git worktreeを使った並列開発
-- 📝 自動PR作成とIssue進捗コメント
-- ⚡ 複数Issue同時処理（worker数に応じて、デフォルト最大3件）
+**System Characteristics:**
+- 🔄 Automatic GitHub Issue monitoring and assignment
+- 🚀 Parallel development using Git worktree
+- 📝 Automatic PR creation and Issue progress comments
+- ⚡ Multiple concurrent Issue processing (up to max 3 by default, based on worker count)
 
 ## Architecture
 
@@ -29,30 +29,30 @@ graph TB
     PRs[🔀 Pull Requests]
 
     %% AI Agents
-    IssueManager[🎯 Issue Manager<br/>GitHub Issue監視・調整]
-    Worker1[👷 Worker1<br/>Issue解決専門]
-    Worker2[👷 Worker2<br/>Issue解決専門]
-    Worker3[👷 Worker3<br/>Issue解決専門]
+    IssueManager[🎯 Issue Manager<br/>GitHub Issue monitoring & coordination]
+    Worker1[👷 Worker1<br/>Issue resolution specialist]
+    Worker2[👷 Worker2<br/>Issue resolution specialist]
+    Worker3[👷 Worker3<br/>Issue resolution specialist]
 
     %% Development Environment
     MainBranch[🌳 main branch]
-    Worktree1[🌿 worktree-1<br/>独立作業環境]
-    Worktree2[🌿 worktree-2<br/>独立作業環境]
-    Worktree3[🌿 worktree-3<br/>独立作業環境]
+    Worktree1[🌿 worktree-1<br/>independent work environment]
+    Worktree2[🌿 worktree-2<br/>independent work environment]
+    Worktree3[🌿 worktree-3<br/>independent work environment]
 
     %% Terminal Environment
-    Tmux[📺 tmux session<br/>4分割画面]
+    Tmux[📺 tmux session<br/>4-panel display]
     ClaudeCLI[🤖 Claude CLI<br/>--dangerously-skip-permissions]
 
     %% Workflow Process
-    NewIssue[🆕 新しいIssue作成]
-    IssueMonitoring[👁️ Issue監視]
-    WorkerAssign[📋 Worker自動アサイン]
-    Analysis[🔍 Issue内容分析]
-    Implementation[⚙️ 実装・テスト]
-    PRCreation[📝 PR作成]
-    QualityCheck[✅ 品質確認]
-    Merge[🎯 マージ承認]
+    NewIssue[🆕 New Issue creation]
+    IssueMonitoring[👁️ Issue monitoring]
+    WorkerAssign[📋 Automatic Worker assignment]
+    Analysis[🔍 Issue content analysis]
+    Implementation[⚙️ Implementation & Testing]
+    PRCreation[📝 PR creation]
+    QualityCheck[✅ Quality verification]
+    Merge[🎯 Merge approval]
 
     %% Connections - GitHub Integration
     GitHub --> Issues
@@ -140,111 +140,111 @@ graph TB
 
 ## Getting Started
 
-### Prerequisite
-- Mac または Linux
-- tmux（ターミナル分割ツール）: `brew install tmux`
+### Prerequisites
+- Mac or Linux
+- tmux (terminal splitting tool): `brew install tmux`
 
     `~/.tmux.conf`:
 
     ```
-    # マウス操作を有効にする
+    # Enable mouse operations
     set-option -g mouse on
 
-    # ダブルクリックでタイルレイアウトに変更
+    # Switch to tiled layout on double-click
     bind -n DoubleClick1Pane select-layout tiled
     ```
 
-    詳細設定: [.tmux](.tmux/README.md)
+    Detailed configuration: [.tmux](.tmux/README.md)
 
 - Claude Code CLI
-- gh CLI（GitHub CLI）
+- gh CLI (GitHub CLI)
 
 ### Usage
 
-#### 1️⃣ インストール
-**対象のGitレポでインストール**
+#### 1️⃣ Installation
+**Install in target Git repository**
 ```bash
-# 最新版（mainブランチ）
+# Latest version (main branch)
 curl -sSL https://raw.githubusercontent.com/nakamasato/Claude-Code-GitHub-Issue-Management/main/install.sh | bash
 
-# 特定のバージョン（タグ指定）
+# Specific version (tag specification)
 GITHUB_REF=v1.0.0
 curl -sSL "https://raw.githubusercontent.com/nakamasato/Claude-Code-GitHub-Issue-Management/$GITHUB_REF/install.sh" | bash -s -- --ref "$GITHUB_REF"
 ```
 
 ![](install.gif)
 
-インストール完了後のファイル構成：
+File structure after installation:
 ```
 your-project/
-├── claude/                     # GitHub Issue管理システム
+├── claude/                     # GitHub Issue management system
 │   ├── instructions/
-│   │   ├── issue-manager.md   # Issue Manager指示書
-│   │   └── worker.md          # Worker指示書
-│   ├── agent-send.sh          # エージェント間通信スクリプト
-│   ├── setup.sh               # tmux環境セットアップ
-│   └── local-verification.md  # ローカル動作確認手順
-├── CLAUDE.md                   # メイン設定ファイル（要手動追記）
-└── .gitignore                  # 自動更新（worktree/,tmp/,logs/追加）
+│   │   ├── issue-manager.md   # Issue Manager instructions
+│   │   └── worker.md          # Worker instructions
+│   ├── agent-send.sh          # Inter-agent communication script
+│   ├── setup.sh               # tmux environment setup
+│   └── local-verification.md  # Local verification procedures
+├── CLAUDE.md                   # Main configuration file (manual addition required)
+└── .gitignore                  # Auto-updated (worktree/, tmp/, logs/ added)
 ```
 
-**CLAUDE.mdに設定を追加**
+**Add configuration to CLAUDE.md**
 
-インストール後に表示される内容をCLAUDE.mdファイルに追記してください：
+Please add the content displayed after installation to your CLAUDE.md file:
 
 ````markdown
 ---
 
 # GitHub Issue Management System
 
-## エージェント構成
-- **issue-manager** (multiagent:0.0): GitHub Issue管理者
-- **worker1-N** (multiagent:0.1-N): Issue解決担当（Nはsetup.shで指定、デフォルト3）
+## Agent Configuration
+- **issue-manager** (multiagent:0.0): GitHub Issue Manager
+- **worker1-N** (multiagent:0.1-N): Issue Resolution Workers (N specified in setup.sh, default 3)
 
-## あなたの役割
+## Your Role
 - **issue-manager**: @claude/instructions/issue-manager.md
 - **worker1-N**: @claude/instructions/worker.md
 
-## メッセージ送信
+## Message Sending
 ```bash
-./claude/agent-send.sh [相手] "[メッセージ]"
+./claude/agent-send.sh [recipient] "[message]"
 ```
 
-## 基本フロー
+## Basic Flow
 GitHub Issues → issue-manager → workers → issue-manager → GitHub PRs
 ````
 
 > [!WARNING]
-> **この時点で一度コミットしてmainへPushしてください。**
-> issue-managerとworkerは常に最新mainから始めるためにmain branchにこれらのscriptとinstructionが入っている必要があります。
+> **Please commit and push to main at this point.**
+> The issue-manager and workers always start from the latest main, so these scripts and instructions need to be in the main branch.
 
-#### 2️⃣ 環境構築
+#### 2️⃣ Environment Setup
 ```bash
-./claude/setup.sh          # デフォルト: 3 workers
+./claude/setup.sh          # Default: 3 workers
 
-# Worker数を指定
+# Specify number of workers
 ./claude/setup.sh 5        # 5 workers
 
-# Claude引数を指定（ヘルプ表示）
+# Specify Claude arguments (show help)
 ./claude/setup.sh --help
 
-# Claude引数を指定した実行例
-ISSUE_MANAGER_ARGS='' WORKER_ARGS='' ./claude/setup.sh                   # Claude引数なしで実行
+# Example execution with Claude arguments
+ISSUE_MANAGER_ARGS='' WORKER_ARGS='' ./claude/setup.sh                   # Run without Claude arguments
 ISSUE_MANAGER_ARGS='--model claude-3-5-sonnet-20241022' \
-WORKER_ARGS='--model claude-3-5-sonnet-20241022' ./claude/setup.sh      # 特定のモデルを指定
+WORKER_ARGS='--model claude-3-5-sonnet-20241022' ./claude/setup.sh      # Specify particular model
 ```
-これでバックグラウンドに指定した数のターミナル画面が準備されます！
+This prepares the specified number of terminal windows in the background!
 
-Claude Codeは既に全ペインで起動済みです！ブラウザでのClaude認証が必要な場合があります。
+Claude Code is already running in all panes! Browser authentication for Claude may be required.
 
-#### 3️⃣ Issue Manager画面を開いてAI起動
+#### 3️⃣ Open Issue Manager screen and start AI
 
-**Issue Manager画面を開く：**
+**Open Issue Manager screen:**
 ```bash
 tmux attach-session -t multiagent
 ```
 
-指定したworker数に応じた分割画面が表示されます（デフォルト: issue-manager + 3 workers）：
+A split screen corresponding to the specified number of workers will be displayed (default: issue-manager + 3 workers):
 ```
 ┌─────────────┬─────────────┐
 │issue-manager│   worker1   │
@@ -253,307 +253,303 @@ tmux attach-session -t multiagent
 └─────────────┴─────────────┘
 ```
 
-#### 4️⃣ GitHub Issue管理開始
+#### 4️⃣ Start GitHub Issue Management
 
-Issue Manager画面で入力(defaultでは assignee:@me のissueが対象)：
+Input in Issue Manager screen (default targets issues with assignee:@me):
 ```
-あなたはissue-managerです。指示書に従ってGitHub Issueの監視を開始してください。
-```
-
-対象Issueを絞る場合:
-```
-あなたはissue-managerです。指示書に従ってGitHub Issueの監視を開始してください。対象とするissueの条件は、未アサイン且つbugラベルのissueです。
+You are the issue-manager. Please start monitoring GitHub Issues according to the instructions.
 ```
 
-**すると自動的に：**
-1. Issue ManagerがGitHub Issueを監視
-2. 新しいIssueが作成されるとWorkerにアサイン
-3. WorkerがIssue解決とPR作成
-4. Issue Managerが確認・品質管理
+To narrow down target Issues:
+```
+You are the issue-manager. Please start monitoring GitHub Issues according to the instructions. The target issue condition is unassigned issues with bug labels.
+```
 
-#### 🗑️ アンインストール
+**Then automatically:**
+1. Issue Manager monitors GitHub Issues
+2. When new Issues are created, they are assigned to Workers
+3. Workers resolve Issues and create PRs
+4. Issue Manager performs verification and quality management
+
+#### 🗑️ Uninstallation
 ```bash
-# GitHub Issue管理システムを削除
+# Remove GitHub Issue management system
 rm -rf ./claude
 ```
 
-## 🏢 登場人物（エージェント）
+## 🏢 Characters (Agents)
 
 ### 🎯 Issue Manager
-- **役割**: GitHub Issue管理・Worker調整
-- **機能**:
-  - Issue監視とアサイン
-  - Worker環境セットアップ
-  - PR確認と品質管理
-  - ローカル動作確認
-- **口癖**: 「Issue #123をWorker1にアサインしました」
+- **Role**: GitHub Issue management and Worker coordination
+- **Functions**:
+  - Issue monitoring and assignment
+  - Worker environment setup
+  - PR verification and quality management
+  - Local operation verification
+- **Catchphrase**: "Assigned Issue #123 to Worker1"
 
-### 👷 Worker1〜N（デフォルト3、setup.shで指定可能）
-- **役割**: Issue解決専門エンジニア
-- **機能**:
-  - Git worktree環境構築
-  - Issue内容分析と実装
-  - PR作成とIssueコメント
-  - テスト実行と品質確保
-- **口癖**: 「Issue #123の解決が完了しました」
+### 👷 Worker1~N (default 3, configurable in setup.sh)
+- **Role**: Issue resolution specialist engineer
+- **Functions**:
+  - Git worktree environment setup
+  - Issue content analysis and implementation
+  - PR creation and Issue comments
+  - Test execution and quality assurance
+- **Catchphrase**: "Issue #123 resolution completed"
 
-## 💬 どうやってコミュニケーションする？
+## 💬 How Do They Communicate?
 
-### メッセージの送り方
+### How to Send Messages
 ```bash
-./claude/agent-send.sh [相手の名前] "[メッセージ]"
+./claude/agent-send.sh [recipient name] "[message]"
 
-# 例：Issue Managerに送る
-./claude/agent-send.sh issue-manager "GitHub Issue確認をお願いします"
+# Example: Send to Issue Manager
+./claude/agent-send.sh issue-manager "Please check GitHub Issues"
 
-# 例：Worker1に送る
-./claude/agent-send.sh worker1 "Issue #123をアサインしました"
+# Example: Send to Worker1
+./claude/agent-send.sh worker1 "Assigned Issue #123"
 ```
 
-### 実際のやり取りの例
+### Example of Actual Communication
 
-**Issue Manager → Worker：**
+**Issue Manager → Worker:**
 ```
-あなたはworker1です。
+You are worker1.
 
 【GitHub Issue Assignment】
 Issue #123: Add dark mode toggle feature
 
-以下の手順で作業環境をセットアップしてください：
+Please set up the work environment with the following steps:
 
-1. Git環境の準備
+1. Git environment preparation
    git checkout main
    git pull origin main
    mkdir -p worktree
 
-   # 既存のworktreeがあるかチェック
+   # Check if existing worktree exists
    if [ -d "worktree/issue-123" ]; then
-     echo "既存のworktree/issue-123を使用します"
+     echo "Using existing worktree/issue-123"
      cd worktree/issue-123
    else
-     echo "新しいworktreeを作成します"
+     echo "Creating new worktree"
      git worktree add worktree/issue-123 -b issue-123
      cd worktree/issue-123
    fi
 
-2. Issue詳細確認
+2. Issue details verification
    gh issue view 123
 
-3. タスクリスト作成と実装開始
+3. Create task list and start implementation
 
-進捗や質問があれば随時報告してください。
+Please report progress or questions as needed.
 ```
 
-**Worker → Issue Manager：**
+**Worker → Issue Manager:**
 ```
-【Issue #123 完了報告】Worker1
+【Issue #123 Completion Report】Worker1
 
-## 実装内容
-- ダークモード切り替えボタンを追加
-- CSS変数を使用したテーマシステム実装
-- ローカルストレージでユーザー設定保存
+## Implementation Details
+- Added dark mode toggle button
+- Implemented theme system using CSS variables
+- Save user settings to localStorage
 
 ## Pull Request
-PR #45 を作成済みです。
-- ブランチ: issue-123
-- テスト: 全て通過
+PR #45 has been created.
+- Branch: issue-123
+- Tests: All passed
 
-次のIssueがあればアサインをお願いします！
+Please assign the next Issue if available!
 ```
 
-## 📁 重要なファイルの説明
+## 📁 Important File Descriptions
 
-### 指示書（claude/instructions/）
-各エージェントの行動マニュアルです
+### Instructions (claude/instructions/)
+Behavior manuals for each agent
 
-**claude/instructions/issue-manager.md** - Issue Manager指示書
+**claude/instructions/issue-manager.md** - Issue Manager Instructions
 ```markdown
-# あなたの役割
-GitHub Issueを常に監視し、効率的にWorkerに作業をアサインして
-プロジェクトを進行管理する
+# Your Role
+Monitor GitHub Issues continuously and efficiently assign work to Workers
+to manage project progress
 
-## 基本動作フロー
-1. Issue監視: GitHub Issue一覧をチェック
-2. Worker管理: 各Workerの作業状況を把握
-3. Issue割り当て: 適切なWorkerにAssign
-4. 環境準備: Workerの開発環境セットアップ
-5. 進捗管理: 報告受信とPR確認
+## Basic Operation Flow
+1. Issue monitoring: Check GitHub Issue list
+2. Worker management: Track each Worker's work status
+3. Issue assignment: Assign to appropriate Worker
+4. Environment preparation: Worker development environment setup
+5. Progress management: Receive reports and check PRs
 ```
 
-**claude/instructions/worker.md** - Worker指示書
+**claude/instructions/worker.md** - Worker Instructions
 ```markdown
-# あなたの役割
-GitHub Issueの解決を専門とする開発者として、
-Issue Managerからアサインされたタスクを効率的に実行
+# Your Role
+As a developer specializing in GitHub Issue resolution,
+efficiently execute tasks assigned by Issue Manager
 
-## 実行フロー
-1. 環境セットアップ: Git worktreeとブランチ作成
-2. Issue分析: 内容理解とタスク化
-3. 実装とテスト: 段階的な機能実装
-4. PR作成と報告: Pull Request作成と完了報告
+## Execution Flow
+1. Environment setup: Git worktree and branch creation
+2. Issue analysis: Content understanding and task creation
+3. Implementation and testing: Gradual feature implementation
+4. PR creation and reporting: Pull Request creation and completion report
 ```
 
 ### CLAUDE.md
-システム全体の設定ファイル
+System-wide configuration file
 ```markdown
 # GitHub Issue Management System
 
-## エージェント構成
-- issue-manager: GitHub Issue管理者
-- worker1,2,3: Issue解決担当
+## Agent Configuration
+- issue-manager: GitHub Issue Manager
+- worker1,2,3: Issue Resolution Workers
 
-## 基本フロー
+## Basic Flow
 GitHub Issues → issue-manager → workers → GitHub PRs
 ```
 
-## 🎯 GitHub Issue管理のワークフロー
+## 🎯 GitHub Issue Management Workflow
 
-### 典型的なフロー
-1. **Issue作成**: 開発者がGitHub上でIssueを作成
-2. **自動監視**: Issue ManagerがIssue一覧を定期監視
-3. **Worker割り当て**: 空いているWorkerにIssueをアサイン
-4. **環境準備**: Workerに自動で環境セットアップ指示
-5. **Issue解決**: WorkerがIssue内容を分析し実装
-6. **PR作成**: Workerが完了時に自動でPull Request作成
-7. **品質確認**: Issue ManagerがPRとIssueを確認
-8. **完了処理**: マージ後、次のIssueを割り当て
+### Typical Flow
+1. **Issue Creation**: Developer creates Issue on GitHub
+2. **Automatic Monitoring**: Issue Manager periodically monitors Issue list
+3. **Worker Assignment**: Assign Issue to available Worker
+4. **Environment Preparation**: Automatically instruct Worker to set up environment
+5. **Issue Resolution**: Worker analyzes Issue content and implements
+6. **PR Creation**: Worker automatically creates Pull Request upon completion
+7. **Quality Verification**: Issue Manager verifies PR and Issue
+8. **Completion Processing**: After merge, assign next Issue
 
-### サポートする機能
-- ✅ **並列処理**: 最大3つのIssueを同時に処理
-- ✅ **Git worktree**: ブランチごとに独立した作業環境
-- ✅ **自動コメント**: Issue進捗の自動記録
-- ✅ **品質管理**: ローカル確認とテスト実行
+### Supported Features
+- ✅ **Parallel Processing**: Process up to 3 Issues simultaneously
+- ✅ **Git worktree**: Independent work environment for each branch
+- ✅ **Automatic Comments**: Automatic recording of Issue progress
+- ✅ **Quality Management**: Local verification and test execution
 
-## 🌿 Git Worktree管理システム
+## 🌿 Git Worktree Management System
 
-### Worktreeの使用目的
-GitHub Issue管理システムでは、各IssueごとにGit worktreeを作成し、並列開発を可能にします。
+### Purpose of Worktree Usage
+The GitHub Issue management system creates Git worktree for each Issue, enabling parallel development.
 
-### 🛡️ Worker安全環境の強化
-Issue #6で実装された重要な安全対策：
+### 🛡️ Worker Safe Environment Enhancement
+Important safety measures implemented in Issue #6:
 
-#### Worker環境分離
-- **Claude起動制御**: setup.shはissue-managerのみClaude起動、workersは待機状態
-- **自動worktree移行**: Issue割り当て時にworkerを自動的にworktreeディレクトリに移行
-- **プロセス検出**: `pane_current_command`でClaude実行状態を正確に判定
-- **安全終了**: agent-send.shによるClaude安全終了でシェル終了を防止
+#### Worker Environment Isolation
+- **Claude Launch Control**: setup.sh launches Claude only for issue-manager, workers are in standby state
+- **Automatic worktree Migration**: Automatically migrate worker to worktree directory when Issue is assigned
+- **Process Detection**: Accurately determine Claude execution state with `pane_current_command`
+- **Safe Exit**: Prevent shell termination through safe Claude exit via agent-send.sh
 
-#### 動作フロー
+#### Operation Flow
 ```bash
-# 初期状態（setup.sh実行後）
-issue-manager: Claude起動済み（rootディレクトリ）
-worker1-N: 待機メッセージ表示（Claudeは未起動）
+# Initial state (after setup.sh execution)
+issue-manager: Claude launched (root directory)
+worker1-N: Standby message displayed (Claude not launched)
 
-# Issue割り当て時
-1. worktree作成/確認
-2. workerプロセス状態確認（zsh/node）
-   - zsh → 直接Claude起動
-   - node → agent-send.sh でexit → Claude再起動
-3. worktreeディレクトリに移動
-4. Claude再起動
+# During Issue assignment
+1. Create/verify worktree
+2. Check worker process state (zsh/node)
+   - zsh → Launch Claude directly
+   - node → Exit via agent-send.sh → Restart Claude
+3. Move to worktree directory
+4. Restart Claude
 
-# Issue完了時
-1. workerプロセス状態確認
-2. Claude安全終了（実行中の場合）
-3. rootディレクトリに復帰
-4. 待機状態に戻る
+# Upon Issue completion
+1. Check worker process state
+2. Safe Claude exit (if running)
+3. Return to root directory
+4. Return to standby state
 ```
 
-#### セキュリティメリット
-- **mainブランチ保護**: workerが誤ってrootディレクトリで作業することを防止
-- **環境完全分離**: 各Issueが独立したworktree環境で実行
-- **自動復旧**: Issue完了時にworkerが自動的にクリーンな状態に復帰
+#### Security Benefits
+- **Main Branch Protection**: Prevent worker from accidentally working in root directory
+- **Complete Environment Isolation**: Each Issue executes in independent worktree environment
+- **Automatic Recovery**: Worker automatically returns to clean state upon Issue completion
 
-### Worktreeディレクトリ構造
+### Worktree Directory Structure
 ```
 project-root/
 ├── .git/
 ├── main-code-files...
-├── worktree/               # Worktree専用ディレクトリ
-│   ├── issue-123/         # Issue #123用の作業環境
-│   ├── issue-456/         # Issue #456用の作業環境
-│   └── issue-789/         # Issue #789用の作業環境
-└── .gitignore             # worktree/が自動追加される
+├── worktree/               # Worktree dedicated directory
+│   ├── issue-123/         # Work environment for Issue #123
+│   ├── issue-456/         # Work environment for Issue #456
+│   └── issue-789/         # Work environment for Issue #789
+└── .gitignore             # worktree/ automatically added
 ```
 
 > [!NOTE]
-> `setup.sh`で`worktree/`を`.gitignore`に追加します。
+> `setup.sh` adds `worktree/` to `.gitignore`.
 
-### Worktreeライフサイクル
+### Worktree Lifecycle
 
-1. **作成**:
-   - 既存worktreeディレクトリをチェック (`-d "worktree/issue-XXX"`)
-   - 存在する場合：既存worktreeにcdして継続
-   - 存在しない場合：`git worktree add worktree/issue-XXX -b issue-XXX`
-2. **開発**: 独立した環境でIssue解決作業
-3. **確認**: Issue Managerによる品質チェック
-4. **削除**: `git worktree remove worktree/issue-XXX --force`
+1. **Creation**:
+   - Check existing worktree directory (`-d "worktree/issue-XXX"`)
+   - If exists: cd to existing worktree and continue
+   - If not exists: `git worktree add worktree/issue-XXX -b issue-XXX`
+2. **Development**: Issue resolution work in independent environment
+3. **Verification**: Quality check by Issue Manager
+4. **Deletion**: `git worktree remove worktree/issue-XXX --force`
 
-### セキュリティとメリット
+### Security and Benefits
 
-#### Claude Codeセキュリティ準拠
-- **子ディレクトリ制限**: `worktree/`は子ディレクトリなので安全
-- **パス制限回避**: `../`パスを使用しない設計
+#### Claude Code Security Compliance
+- **Subdirectory Restriction**: `worktree/` is a subdirectory so it's safe
+- **Path Restriction Avoidance**: Design that doesn't use `../` paths
 
-#### 開発効率向上
-- **並列開発**: 最大3つのIssue同時処理
-- **環境分離**: 各Issueで完全に独立した環境
-- **依存関係隔離**: 異なるパッケージバージョンでも競合なし
-- **ブランチ管理**: 自動的な`issue-XXX`ブランチ作成
+#### Development Efficiency Improvement
+- **Parallel Development**: Process up to 3 Issues simultaneously
+- **Environment Isolation**: Completely independent environment for each Issue
+- **Dependency Isolation**: No conflicts even with different package versions
+- **Branch Management**: Automatic `issue-XXX` branch creation
 
-#### 自動管理
-- **`.gitignore`自動更新**: `worktree/`エントリの自動追加
-- **ディレクトリ作成**: セットアップ時の自動作成
-- **自動クリーンアップ**: Issue完了時の自動削除
+#### Automatic Management
+- **Automatic `.gitignore` Update**: Automatic addition of `worktree/` entry
+- **Directory Creation**: Automatic creation during setup
+- **Automatic Cleanup**: Automatic deletion upon Issue completion
 
+### Troubleshooting
 
-
-### トラブルシューティング
-
-#### Worktreeが残ってしまった場合
+#### When Worktree Remains
 ```bash
-# 手動クリーンアップ
+# Manual cleanup
 git worktree list
 git worktree remove worktree/issue-XXX --force
 rm -rf worktree/issue-XXX
 ```
 
+## 🔧 When in Trouble
 
-
-## 🔧 困ったときは
-
-### Q: エージェントが反応しない
+### Q: Agent doesn't respond
 ```bash
-# 状態を確認
+# Check status
 tmux ls
 
-# 再起動
+# Restart
 ./setup.sh
 ```
 
-### Q: メッセージが届かない
+### Q: Messages don't arrive
 ```bash
-# ログを見る
+# Check logs
 cat logs/send_log.txt
 
-# 手動でテスト
-./agent-send.sh issue-manager "テスト"
-./agent-send.sh worker1 "テスト"
+# Manual test
+./agent-send.sh issue-manager "Test"
+./agent-send.sh worker1 "Test"
 ```
 
-### Q: 最初からやり直したい
+### Q: Want to start over
 ```bash
-# 全部リセット
+# Reset everything
 tmux kill-server
 rm -rf ./tmp/*
 ./setup.sh
 ```
 
-## 🚀 GitHub Issueを作成してテストする
+## 🚀 Create GitHub Issues for Testing
 
-### 簡単な例：GitHub Issue作成とワークフロー
+### Simple Example: GitHub Issue Creation and Workflow
 
-1. **GitHub上でIssueを作成**：
+1. **Create Issue on GitHub**:
 ```
 Title: Add TODO list feature
 Description:
@@ -562,117 +558,117 @@ Description:
 - Save to localStorage
 ```
 
-2. **Issue Managerが自動で動作**：
+2. **Issue Manager automatically operates**:
 ```bash
-# Issue Managerで確認
-./agent-send.sh issue-manager "GitHub Issueの監視を開始してください"
+# Verify with Issue Manager
+./agent-send.sh issue-manager "Please start monitoring GitHub Issues"
 ```
 
-3. **自動実行される流れ**：
-   - Issue Managerが新しいIssueを検出
-   - 空いているWorkerにアサイン
-   - WorkerがIssue解決とPR作成
-   - Issue ManagerがPR確認
+3. **Automatically executed flow**:
+   - Issue Manager detects new Issue
+   - Assign to available Worker
+   - Worker resolves Issue and creates PR
+   - Issue Manager verifies PR
 
-## 📊 システムの仕組み（図解）
+## 📊 System Mechanism (Illustrated)
 
-### 画面構成
+### Screen Layout
 ```
 ┌─────────────┬─────────────┐
-│issue-manager│   worker1   │ ← Issue Manager（緑）とWorker1（青）
+│issue-manager│   worker1   │ ← Issue Manager (green) and Worker1 (blue)
 ├─────────────┼─────────────┤
-│   worker2   │   worker3   │ ← Worker2と3（青）
+│   worker2   │   worker3   │ ← Worker2 and 3 (blue)
 └─────────────┴─────────────┘
 ```
 
-### GitHub Issue管理の流れ
+### GitHub Issue Management Flow
 ```
 GitHub Issues
- ↓ 「Issue #123作成」
+ ↓ "Issue #123 created"
 Issue Manager
- ↓ 「Worker1に割り当て」
+ ↓ "Assign to Worker1"
 Worker1
- ↓ 「Issue解決、PR作成」
+ ↓ "Resolve Issue, create PR"
 Issue Manager
- ↓ 「PR確認・品質チェック」
+ ↓ "Verify PR, quality check"
 GitHub PR Merge
 ```
 
-### 進捗管理の仕組み
+### Progress Management Mechanism
 ```
 ./tmp/worker-status/
-├── worker1_busy.txt     # Worker1の作業中Issueを記録
-├── worker2_busy.txt     # Worker2の作業中Issueを記録
-├── worker3_busy.txt     # Worker3の作業中Issueを記録
-└── worker*_progress.log # 各Workerの進捗記録
+├── worker1_busy.txt     # Record Worker1's active Issue
+├── worker2_busy.txt     # Record Worker2's active Issue
+├── worker3_busy.txt     # Record Worker3's active Issue
+└── worker*_progress.log # Progress record for each Worker
 ```
 
-## 💡 なぜこれがすごいの？
+## 💡 Why is This Amazing?
 
-### 従来のIssue管理
+### Traditional Issue Management
 ```
-開発者 → Issue作成 → 手動割り当て → 個別実装 → 手動PR → レビュー
-```
-
-### AIワークフローシステム
-```
-開発者 → Issue作成 → AI自動監視 → AI自動割り当て → AI並列実装 → AI自動PR → AI品質確認
+Developer → Create Issue → Manual assignment → Individual implementation → Manual PR → Review
 ```
 
-**メリット：**
-- 🔄 **完全自動化**: Issue発見からPR作成まで自動
-- ⚡ **並列処理**: 3つのIssueを同時に処理可能
-- 🎯 **専門特化**: 各AI WorkerがIssue解決に特化
-- 📊 **透明性**: GitHub上で全プロセスが可視化
+### AI Workflow System
+```
+Developer → Create Issue → AI auto-monitoring → AI auto-assignment → AI parallel implementation → AI auto-PR → AI quality verification
+```
 
-## 🎓 もっと詳しく知りたい人へ
+**Benefits:**
+- 🔄 **Complete Automation**: Automatic from Issue discovery to PR creation
+- ⚡ **Parallel Processing**: Can process 3 Issues simultaneously
+- 🎯 **Specialized Focus**: Each AI Worker specializes in Issue resolution
+- 📊 **Transparency**: All processes visualized on GitHub
 
-### GitHub Issue作成のベストプラクティス
+## 🎓 For Those Who Want to Learn More
 
-**良いIssue例：**
+### GitHub Issue Creation Best Practices
+
+**Good Issue Example:**
 ```
 Title: Add user authentication feature
 
 Description:
-## 要件
-- ユーザー登録・ログイン機能
-- JWTトークンベース認証
-- パスワード暗号化
+## Requirements
+- User registration and login functionality
+- JWT token-based authentication
+- Password encryption
 
 ## Acceptance Criteria
-- [ ] 新規ユーザー登録ができる
-- [ ] 既存ユーザーがログインできる
-- [ ] 認証状態が維持される
+- [ ] New users can register
+- [ ] Existing users can log in
+- [ ] Authentication state is maintained
 
-## 技術仕様
-- 使用技術: Node.js, bcrypt, JWT
-- DB: user テーブル追加
+## Technical Specifications
+- Technology: Node.js, bcrypt, JWT
+- DB: Add user table
 ```
 
-**悪いIssue例：**
+**Bad Issue Example:**
 ```
-ログイン機能作って
+Create login functionality
 ```
 
-**Issue監視間隔を変更：**
+**Change Issue monitoring interval:**
 ```bash
-# instructions/issue-manager.md の中の
-sleep 600  # 10分を5分に変更するなら
+# In instructions/issue-manager.md
+sleep 600  # Change 10 minutes to 5 minutes
 sleep 300
 ```
 
-## 🌟 まとめ
+## 🌟 Summary
 
-このGitHub Issue管理システムは、AI協調による開発ワークフローで：
-- 🔄 **Issue → PR完全自動化**
-- ⚡ **最大3件の並列Issue処理**
-- 🎯 **Git worktreeによる効率的開発**
-- 📊 **GitHub上での透明な進捗管理**
+This GitHub Issue management system provides AI-collaborative development workflow with:
+- 🔄 **Complete Issue → PR automation**
+- ⚡ **Up to 3 parallel Issue processing**
+- 🎯 **Efficient development with Git worktree**
+- 📊 **Transparent progress management on GitHub**
 
-GitHub Issueの管理を自動化し、開発効率を劇的に向上させます！
+Automate GitHub Issue management and dramatically improve development efficiency!
 
 ---
 
-**作者**: [GitHub](https://github.com/nishimoto265/Claude-Code-Communication)
-**ライセンス**: MIT
-**質問**: [Issues](https://github.com/nishimoto265/Claude-Code-Communication/issues)へどうぞ！
+**Author**: [GitHub](https://github.com/nishimoto265/Claude-Code-Communication)
+**License**: MIT
+**Questions**: Please visit [Issues](https://github.com/nishimoto265/Claude-Code-Communication/issues)!

--- a/claude/instructions/issue-manager.md
+++ b/claude/instructions/issue-manager.md
@@ -1,72 +1,72 @@
-# 🎯 GitHub Issue Manager指示書
+# 🎯 GitHub Issue Manager Instructions
 
-## あなたの役割
-GitHub Issueを常に監視し、効率的にWorkerに作業をアサインしてプロジェクトを進行管理する
+## Your Role
+Continuously monitor GitHub Issues and efficiently assign work to Workers for project management
 
-## 基本動作フロー
-1. **Issue監視**: 定期的にGitHub Issue一覧をチェックし、Openで且つユーザから依頼された条件があればその条件にマッチするissueを確認
-2. **Worker管理**: 各Workerの作業状況を把握し、空いているWorkerを特定
-3. **Issue割り当て**: 適切なWorkerにIssueをAssignし、ラベルを付与
-4. **環境準備**: AssignされたWorkerに対して開発環境のセットアップを指示
-5. **進捗管理**: Workerからの報告を受けて、IssueとPRの状況を確認
-6. **品質管理**: 必要に応じてローカル環境での動作確認を実施
+## Basic Workflow
+1. **Issue Monitoring**: Regularly check GitHub Issue list, and if there are user-requested conditions, confirm issues that match those conditions for Open issues
+2. **Worker Management**: Track each Worker's work status and identify available Workers
+3. **Issue Assignment**: Assign Issues to appropriate Workers and add labels
+4. **Environment Setup**: Instruct assigned Workers to set up development environment
+5. **Progress Management**: Receive reports from Workers and check Issue and PR status
+6. **Quality Management**: Perform local environment verification as needed
 
-## Worker設定
-### Worker数の設定
+## Worker Configuration
+### Worker Count Setting
 ```bash
-# Worker数を設定（デフォルト: 3）
+# Set Worker count (default: 3)
 WORKER_COUNT=${WORKER_COUNT:-3}
 
-# Worker数確認
-echo "設定されたWorker数: $WORKER_COUNT"
+# Check Worker count
+echo "Configured Worker count: $WORKER_COUNT"
 ```
 
-## Issue監視とWorker管理
-### 1. GitHub Issue確認コマンド
+## Issue Monitoring and Worker Management
+### 1. GitHub Issue Check Commands
 ```bash
-# オープンなIssueを一覧表示
+# List open Issues
 gh issue list --state open --json number,title,assignees,labels
 
-# オープンかつ@meにassignされているissue
+# Open issues assigned to @me
 gh issue list --state open --search "assignee:@me" --json number,title,assignees,labels
 
-# オープンかつfilter条件に合うissue
+# Open issues matching filter conditions
 gh issue list --state open --search "[search query]"
 
-# 特定のIssueの詳細確認
+# Check specific Issue details
 gh issue view [issue_number] --json title,body,assignees,labels,comments
 
-# フィルタ条件の詳細な使用例
+# Detailed filter condition usage examples
 gh issue list --state open --search "label:bug"
 gh issue list --state open --search "API in:body"
 ```
 
-### 2. Worker状況管理
+### 2. Worker Status Management
 ```bash
-# Worker状況ファイルの作成・管理
+# Create and manage Worker status files
 mkdir -p ./tmp/worker-status
 
-# Worker1の状況確認
+# Check Worker1 status
 if [ -f ./tmp/worker-status/worker1_busy.txt ]; then
-    echo "Worker1: 作業中 - $(cat ./tmp/worker-status/worker1_busy.txt)"
+    echo "Worker1: Working - $(cat ./tmp/worker-status/worker1_busy.txt)"
 else
-    echo "Worker1: 利用可能"
+    echo "Worker1: Available"
 fi
 
-# 同様にworker2, worker3も確認
+# Similarly check worker2, worker3
 ```
 
-### 3. Issue割り当てロジック
+### 3. Issue Assignment Logic
 ```bash
-# 利用可能なWorkerを見つけてIssueをAssignし、必須の環境セットアップを実行
+# Find available Worker, assign Issue, and execute mandatory environment setup
 assign_issue() {
     local issue_number="$1"
     local issue_title="$2"
 
-    echo "=== Issue #${issue_number} 割り当て処理開始 ==="
-    echo "タイトル: ${issue_title}"
+    echo "=== Issue #${issue_number} assignment process started ==="
+    echo "Title: ${issue_title}"
 
-    # 利用可能なWorkerを探す
+    # Find available Worker
     local assigned_worker=""
     for ((worker_num=1; worker_num<=WORKER_COUNT; worker_num++)); do
         if [ ! -f ./tmp/worker-status/worker${worker_num}_busy.txt ]; then
@@ -75,76 +75,76 @@ assign_issue() {
         fi
     done
 
-    # 利用可能なWorkerがない場合
+    # When no Worker is available
     if [ -z "$assigned_worker" ]; then
-        echo "❌ エラー: 利用可能なWorkerがありません"
-        echo "現在のWorker状況:"
+        echo "❌ Error: No available Workers"
+        echo "Current Worker status:"
         check_worker_load
         return 1
     fi
 
-    echo "✅ Worker${assigned_worker}に割り当て開始"
+    echo "✅ Starting assignment to Worker${assigned_worker}"
 
-    # GitHub上で現在ログインしているユーザーにAssign
-    echo "GitHub Issue #${issue_number}を@meにAssign中..."
+    # Assign to currently logged-in user on GitHub
+    echo "Assigning GitHub Issue #${issue_number} to @me..."
     if ! gh issue edit $issue_number --add-assignee @me; then
-        echo "❌ エラー: GitHub Issue Assignment失敗"
+        echo "❌ Error: GitHub Issue Assignment failed"
         return 1
     fi
 
-    # Worker環境セットアップを実行（必須）
-    echo "=== Worker${assigned_worker}環境セットアップ実行（必須処理） ==="
+    # Execute Worker environment setup (mandatory)
+    echo "=== Worker${assigned_worker} environment setup execution (mandatory process) ==="
     if setup_worker_environment "$assigned_worker" "$issue_number" "$issue_title"; then
-        echo "✅ Issue #${issue_number}のWorker${assigned_worker}への割り当て完了"
-        echo "環境セットアップ成功: $(date)" > "./tmp/worker-status/worker${assigned_worker}_setup_success.txt"
+        echo "✅ Issue #${issue_number} assignment to Worker${assigned_worker} completed"
+        echo "Environment setup success: $(date)" > "./tmp/worker-status/worker${assigned_worker}_setup_success.txt"
         return 0
     else
-        echo "❌ エラー: Worker${assigned_worker}環境セットアップ失敗"
-        echo "GitHub Issue Assignment を取り消します..."
+        echo "❌ Error: Worker${assigned_worker} environment setup failed"
+        echo "Canceling GitHub Issue Assignment..."
 
-        # GitHub Assignmentを取り消し
+        # Cancel GitHub Assignment
         gh issue edit $issue_number --remove-assignee @me
 
-        # Worker状況ファイルがあれば削除
+        # Remove Worker status file if exists
         rm -f "./tmp/worker-status/worker${assigned_worker}_busy.txt"
 
-        echo "環境セットアップ失敗のためIssue #${issue_number}の割り当てを中止しました"
+        echo "Issue #${issue_number} assignment canceled due to environment setup failure"
         return 1
     fi
 }
 
 ```
 
-## Worker環境セットアップ
+## Worker Environment Setup
 
-### 0. 共通関数
+### 0. Common Functions
 ```bash
-# Worker Claudeの実行状態確認関数
+# Worker Claude execution status check function
 check_worker_claude_status() {
     local worker_num="$1"
     local claude_running=false
 
-    # tmuxペインが存在するかチェック
+    # Check if tmux pane exists
     if tmux list-panes -t "multiagent:0.${worker_num}" >/dev/null 2>&1; then
-        # ペインの現在のコマンドを確認
+        # Check current command in pane
         local current_command=$(tmux display-message -p -t "multiagent:0.${worker_num}" "#{pane_current_command}")
 
         if [[ "$current_command" == "zsh" ]] || [[ "$current_command" == "bash" ]] || [[ "$current_command" == "sh" ]]; then
-            echo "ℹ️  worker${worker_num}はシェルモード（Claude未起動）: $current_command"
+            echo "ℹ️  worker${worker_num} is in shell mode (Claude not running): $current_command"
             claude_running=false
         elif [[ "$current_command" == "node" ]] || [[ "$current_command" == "claude" ]]; then
-            echo "✅ worker${worker_num}でClaude実行中を検出: $current_command"
+            echo "✅ Detected Claude running on worker${worker_num}: $current_command"
             claude_running=true
         else
-            echo "ℹ️  worker${worker_num}の不明なプロセス: $current_command (シェルモードとして扱います)"
+            echo "ℹ️  Unknown process on worker${worker_num}: $current_command (treating as shell mode)"
             claude_running=false
         fi
     else
-        echo "❌ worker${worker_num}ペインが見つかりません"
+        echo "❌ worker${worker_num} pane not found"
         return 2
     fi
 
-    # 戻り値: 0=Claude実行中, 1=シェルモード, 2=ペイン不存在
+    # Return values: 0=Claude running, 1=shell mode, 2=pane not exists
     if [ "$claude_running" = true ]; then
         return 0
     else
@@ -152,147 +152,147 @@ check_worker_claude_status() {
     fi
 }
 
-# Worker Claude安全終了関数
+# Worker Claude safe exit function
 safe_exit_worker_claude() {
     local worker_num="$1"
 
-    echo "worker${worker_num}のClaude状態確認中..."
+    echo "Checking worker${worker_num} Claude status..."
     local current_command=$(tmux display-message -p -t "multiagent:0.${worker_num}" "#{pane_current_command}")
 
     if [[ "$current_command" == "zsh" ]] || [[ "$current_command" == "bash" ]] || [[ "$current_command" == "sh" ]]; then
-        echo "ℹ️  worker${worker_num}は既にシェルモード: $current_command (終了処理スキップ)"
+        echo "ℹ️  worker${worker_num} is already in shell mode: $current_command (skipping exit process)"
         return 1
     elif [[ "$current_command" == "node" ]] || [[ "$current_command" == "claude" ]]; then
-        echo "✅ worker${worker_num}でClaude系プロセス実行中: $current_command"
-        echo "Claudeからの安全終了指示送信中..."
+        echo "✅ Claude-related process running on worker${worker_num}: $current_command"
+        echo "Sending safe exit instruction from Claude..."
         ./claude/agent-send.sh worker${worker_num} "exit"
         sleep 3
-        echo "✅ Claude終了指示完了"
+        echo "✅ Claude exit instruction completed"
         return 0
     else
-        echo "ℹ️  worker${worker_num}の不明なプロセス: $current_command (終了処理スキップ)"
+        echo "ℹ️  Unknown process on worker${worker_num}: $current_command (skipping exit process)"
         return 1
     fi
 }
 ```
 
-### 1. Worker初期化処理
+### 1. Worker Initialization Process
 ```bash
 setup_worker_environment() {
     local worker_num="$1"
     local issue_number="$2"
     local issue_title="$3"
 
-    echo "=== Worker${worker_num} 環境セットアップ開始 ==="
+    echo "=== Worker${worker_num} environment setup started ==="
     echo "Issue #${issue_number}: ${issue_title}"
 
-    # 1. Claude安全終了処理
-    echo "=== Worker${worker_num} Claude安全終了処理 ==="
+    # 1. Claude safe exit process
+    echo "=== Worker${worker_num} Claude safe exit process ==="
     safe_exit_worker_claude "$worker_num"
 
-    # 2. worktreeディレクトリの作成
+    # 2. Create worktree directory
     local worktree_path="worktree/issue-${issue_number}"
 
     if git worktree list | grep -q "${worktree_path}"; then
-        echo "既存のworktree/${issue_number}を使用します"
+        echo "Using existing worktree/${issue_number}"
     else
-        echo "新しいworktree/issue-${issue_number}を作成中..."
+        echo "Creating new worktree/issue-${issue_number}..."
 
-        # mainブランチが最新であることを確認
+        # Ensure main branch is up to date
         git checkout main
         git pull origin main
 
-        # 新しいworktreeを作成
+        # Create new worktree
         git worktree add ${worktree_path} -b issue-${issue_number}
     fi
 
-    # 3. worktree安全性チェック
-    echo "=== worktree安全性チェック ==="
+    # 3. Worktree safety check
+    echo "=== worktree safety check ==="
     if [ ! -d "${worktree_path}" ]; then
-        echo "❌ エラー: worktreeディレクトリが作成されていません"
+        echo "❌ Error: worktree directory not created"
         return 1
     fi
 
-    # worktreeが正しく分離されているかチェック
+    # Check if worktree is properly isolated
     local worktree_git_dir=$(cd ${worktree_path} && git rev-parse --git-dir)
     if [[ $worktree_git_dir == *".git/worktrees/"* ]]; then
-        echo "✅ worktreeが正しく分離されています: $worktree_git_dir"
+        echo "✅ worktree is properly isolated: $worktree_git_dir"
     else
-        echo "⚠️  警告: worktreeが期待通りに分離されていません"
+        echo "⚠️  Warning: worktree is not isolated as expected"
     fi
 
-    # 4. worktreeディレクトリでClaude Code起動
-    echo "=== Worker${worker_num} Claude起動処理 ==="
-    echo "worktree/issue-${issue_number}ディレクトリでClaude Codeを起動します"
+    # 4. Start Claude Code in worktree directory
+    echo "=== Worker${worker_num} Claude startup process ==="
+    echo "Starting Claude Code in worktree/issue-${issue_number} directory"
     echo ""
-    echo "【重要な安全対策】"
-    echo "- workerは ${PWD}/${worktree_path} ディレクトリから外に出ることを禁止"
-    echo "- mainブランチの直接編集を禁止"
-    echo "- 作業はissue-${issue_number}ブランチでのみ実行"
+    echo "【Important Safety Measures】"
+    echo "- worker is prohibited from leaving ${PWD}/${worktree_path} directory"
+    echo "- Direct editing of main branch is prohibited"
+    echo "- Work is only allowed on issue-${issue_number} branch"
     echo ""
-    echo "【自動実行手順】"
+    echo "【Automatic Execution Steps】"
 
-    echo "1. worktreeディレクトリに移動"
+    echo "1. Move to worktree directory"
     tmux send-keys -t "multiagent:0.${worker_num}" "cd ${PWD}/${worktree_path}" C-m
 
-    echo "2. worktreeディレクトリでClaude Code起動"
+    echo "2. Start Claude Code in worktree directory"
     tmux send-keys -t "multiagent:0.${worker_num}" "claude ${WORKER_ARGS:-\"--dangerously-skip-permissions\"}" C-m
     sleep 3
 
     echo ""
-    echo "3. worker${worker_num}セッションが起動したら、以下のメッセージを送信:"
+    echo "3. Once worker${worker_num} session starts, send the following message:"
     echo ""
-    echo "=== Worker${worker_num}用メッセージ ==="
-    echo "あなたはworker${worker_num}です。"
+    echo "=== Message for Worker${worker_num} ==="
+    echo "You are worker${worker_num}."
     echo ""
     echo "【GitHub Issue Assignment】"
     echo "Issue #${issue_number}: ${issue_title}"
     echo ""
-    echo "現在のディレクトリは既にissue-${issue_number}ブランチのworktree環境です。"
+    echo "The current directory is already the worktree environment for issue-${issue_number} branch."
     echo ""
-    echo "以下の手順で作業を開始してください："
+    echo "Please start work following these steps:"
     echo ""
-    echo "1. Issue詳細確認"
+    echo "1. Check Issue details"
     echo "   \`\`\`bash"
     echo "   gh issue view ${issue_number}"
     echo "   \`\`\`"
     echo ""
-    echo "2. 作業環境確認"
+    echo "2. Verify work environment"
     echo "   \`\`\`bash"
-    echo "   pwd              # 現在のディレクトリ確認"
-    echo "   git branch       # 現在のブランチ確認"
-    echo "   git status       # 作業ツリーの状態確認"
+    echo "   pwd              # Check current directory"
+    echo "   git branch       # Check current branch"
+    echo "   git status       # Check working tree status"
     echo "   \`\`\`"
     echo ""
-    echo "3. タスクリスト作成"
-    echo "   - Issue内容を分析し、やることリストを作成"
-    echo "   - 実装手順を明確化"
-    echo "   - 必要な技術調査を実施"
+    echo "3. Create task list"
+    echo "   - Analyze Issue content and create todo list"
+    echo "   - Clarify implementation steps"
+    echo "   - Conduct necessary technical research"
     echo ""
-    echo "作業準備が完了したら、Issue解決に向けて実装を開始してください。"
-    echo "進捗や質問があれば随時報告してください。"
+    echo "Once work preparation is complete, start implementation to resolve the Issue."
+    echo "Report progress or questions at any time."
     echo "=========================="
     echo ""
-    echo "上記のworker${worker_num}セッション起動が完了したら、Enterを押してください..."
+    echo "Press Enter once the above worker${worker_num} session startup is complete..."
     read -r
 
-    # 5. Worker状況ファイル作成
-    echo "5. Worker状況ファイル作成"
+    # 5. Create Worker status file
+    echo "5. Create Worker status file"
     mkdir -p ./tmp/worker-status
     echo "Issue #${issue_number}: ${issue_title}" > ./tmp/worker-status/worker${worker_num}_busy.txt
 
-    echo "=== Worker${worker_num} セットアップ完了 ==="
+    echo "=== Worker${worker_num} setup completed ==="
 }
 ```
 
-### 2. 複数Issue防止機能
+### 2. Multiple Issue Prevention Feature
 ```bash
-# Worker重複割り当て防止
+# Prevent Worker duplicate assignment
 check_worker_availability() {
     local worker_num="$1"
 
     if [ -f ./tmp/worker-status/worker${worker_num}_busy.txt ]; then
-        echo "Worker${worker_num}は既に作業中です: $(cat ./tmp/worker-status/worker${worker_num}_busy.txt)"
+        echo "Worker${worker_num} is already working: $(cat ./tmp/worker-status/worker${worker_num}_busy.txt)"
         return 1
     fi
 
@@ -300,320 +300,320 @@ check_worker_availability() {
 }
 ```
 
-## Worker報告処理
+## Worker Report Processing
 
-### Workerからの報告受信フロー
+### Worker Report Reception Flow
 
-Issue Managerは以下の方法でWorkerからの報告を受信します：
+Issue Manager receives reports from Workers through the following methods:
 
-#### 1. **リアルタイム報告受信**
-Workerから`agent-send.sh`でメッセージが送信されると、Issue Manager画面に直接表示されます。
+#### 1. **Real-time Report Reception**
+When Workers send messages via `agent-send.sh`, they are displayed directly on the Issue Manager screen.
 
-#### 2. **報告の種類**
-- **課題報告**: 実装中に問題が発生した場合
-- **進捗報告**: 定期的な進捗アップデート（GitHub Issueコメント経由）
-- **完了報告**: Issue解決とPR作成完了時
+#### 2. **Types of Reports**
+- **Problem Reports**: When issues occur during implementation
+- **Progress Reports**: Regular progress updates (via GitHub Issue comments)
+- **Completion Reports**: When Issue resolution and PR creation are completed
 
-### 1. 課題報告受信処理
+### 1. Problem Report Reception Processing
 ```bash
-# Workerから課題報告を受信した時の対応
+# Handle problem reports received from Workers
 handle_worker_issue_report() {
     local worker_num="$1"
     local issue_number="$2"
     local problem_description="$3"
 
-    echo "Worker${worker_num}からIssue #${issue_number}の課題報告を受信"
-    echo "問題内容: ${problem_description}"
+    echo "Received problem report for Issue #${issue_number} from Worker${worker_num}"
+    echo "Problem details: ${problem_description}"
 
-    # GitHub Issueに課題を記録
-    gh issue comment $issue_number --body "## ⚠️ 実装中の課題報告 - Worker${worker_num}
+    # Record problem in GitHub Issue
+    gh issue comment $issue_number --body "## ⚠️ Implementation Problem Report - Worker${worker_num}
 
-**発生した問題**:
+**Problem Occurred**:
 ${problem_description}
 
-**対応状況**: Issue Manager確認中
+**Response Status**: Issue Manager reviewing
 
-**次のステップ**: 解決策を検討し、Workerに指示します。
+**Next Steps**: Will consider solutions and provide instructions to Worker.
 
 ---
-*Issue Manager による自動記録*"
+*Automatically recorded by Issue Manager*"
 
-    # Workerに対応方針を返信（手動または自動）
-    echo "Worker${worker_num}への対応方針を検討してください："
-    echo "1. 技術的なアドバイスを提供"
-    echo "2. 別のアプローチを提案"
-    echo "3. 他のWorkerに再アサイン"
-    echo "4. Issue要件の明確化"
+    # Response policy to Worker (manual or automatic)
+    echo "Please consider response policy for Worker${worker_num}:"
+    echo "1. Provide technical advice"
+    echo "2. Suggest alternative approach"
+    echo "3. Reassign to another Worker"
+    echo "4. Clarify Issue requirements"
 
-    # 対応例（手動で実行）
-    # ./claude/agent-send.sh worker${worker_num} "課題について以下の解決策を試してください：[具体的な指示]"
+    # Response example (execute manually)
+    # ./claude/agent-send.sh worker${worker_num} "Please try the following solution for the problem: [specific instructions]"
 }
 ```
 
-### 2. 完了報告受信処理
+### 2. Completion Report Reception Processing
 ```bash
-# Workerからの完了報告を受信した時の処理
+# Process completion reports received from Workers
 handle_worker_completion() {
     local worker_num="$1"
     local issue_number="$2"
 
-    echo "Worker${worker_num}からIssue #${issue_number}の完了報告を受信"
+    echo "Received completion report for Issue #${issue_number} from Worker${worker_num}"
 
-    # GitHub Issue確認
-    echo "=== GitHub Issue確認 ==="
+    # Check GitHub Issue
+    echo "=== GitHub Issue Check ==="
     gh issue view $issue_number --json state,comments,title
 
-    # Pull Request確認
-    echo "=== Pull Request確認 ==="
+    # Check Pull Request
+    echo "=== Pull Request Check ==="
     gh pr list --head issue-${issue_number} --json number,title,state,url
 
-    # PR詳細確認
+    # Check PR details
     if pr_number=$(gh pr list --head issue-${issue_number} --json number --jq '.[0].number'); then
-        echo "=== PR #${pr_number} 詳細 ==="
+        echo "=== PR #${pr_number} Details ==="
         gh pr view $pr_number --json title,body,commits,files
 
-        # PRの確認結果をWorkerに通知
-        ./claude/agent-send.sh worker${worker_num} "PR #${pr_number}を確認しました。
+        # Notify Worker of PR check results
+        ./claude/agent-send.sh worker${worker_num} "Checked PR #${pr_number}.
 
-【確認結果】
-- Issue解決状況: 確認中
-- コード変更内容: レビュー中
-- 次のアクション: [承認/修正依頼/追加作業]
+【Check Results】
+- Issue resolution status: Under review
+- Code changes: Under review
+- Next action: [Approval/Correction request/Additional work]
 
-詳細な確認結果は後ほど報告します。"
+Detailed check results will be reported later."
 
-        # ローカル動作確認の実行（オプション）
-        read -p "ローカル動作確認を実行しますか？ (y/N): " -n 1 -r
+        # Execute local verification (optional)
+        read -p "Execute local verification? (y/N): " -n 1 -r
         echo
         if [[ $REPLY =~ ^[Yy]$ ]]; then
             local_verification $issue_number
         fi
     fi
 
-    # Worker Claude セッション終了とworktree環境クリーンアップ
-    echo "=== Worker${worker_num} Claude終了とクリーンアップ ==="
+    # Worker Claude session termination and worktree environment cleanup
+    echo "=== Worker${worker_num} Claude termination and cleanup ==="
 
-    # 1. Worker Claude安全終了
-    echo "1. worker${worker_num}のClaude安全終了処理"
+    # 1. Worker Claude safe termination
+    echo "1. worker${worker_num} Claude safe termination process"
     safe_exit_worker_claude "$worker_num"
 
-    # 2. 元のルートディレクトリに戻る
+    # 2. Return to original root directory
     tmux send-keys -t "multiagent:0.${worker_num}" "cd $(pwd)" C-m
 
-    # 3. 待機メッセージ表示
-    tmux send-keys -t "multiagent:0.${worker_num}" "echo '=== worker${worker_num} 待機中 ==='" C-m
-    tmux send-keys -t "multiagent:0.${worker_num}" "echo 'Issue Managerからの次の割り当てをお待ちください'" C-m
+    # 3. Display standby message
+    tmux send-keys -t "multiagent:0.${worker_num}" "echo '=== worker${worker_num} standby ===' " C-m
+    tmux send-keys -t "multiagent:0.${worker_num}" "echo 'Waiting for next assignment from Issue Manager'" C-m
 
-    # 4. Worker状況ファイル削除（作業完了）
+    # 4. Delete Worker status file (work completed)
     rm -f ./tmp/worker-status/worker${worker_num}_busy.txt
     rm -f ./tmp/worker-status/worker${worker_num}_setup_success.txt
-    # 5. Worktreeクリーンアップ（必要に応じて）
+    # 5. Worktree cleanup (as needed)
     if [ -d "worktree/issue-${issue_number}" ]; then
-        echo "worktree/issue-${issue_number}をクリーンアップ中..."
+        echo "Cleaning up worktree/issue-${issue_number}..."
         git worktree remove worktree/issue-${issue_number} --force 2>/dev/null || true
         rm -rf worktree/issue-${issue_number} 2>/dev/null || true
     fi
 }
 ```
 
-### 3. 進捗モニタリング
+### 3. Progress Monitoring
 ```bash
-# Worker進捗の定期確認
+# Regular Worker progress check
 monitor_worker_progress() {
-    echo "=== Worker進捗確認 ==="
+    echo "=== Worker Progress Check ==="
 
     for ((worker_num=1; worker_num<=WORKER_COUNT; worker_num++)); do
         if [ -f "./tmp/worker-status/worker${worker_num}_busy.txt" ]; then
             local issue_info=$(cat "./tmp/worker-status/worker${worker_num}_busy.txt")
-            echo "Worker${worker_num}: 作業中 - ${issue_info}"
+            echo "Worker${worker_num}: Working - ${issue_info}"
 
-            # GitHub Issueの最新コメントを確認
+            # Check latest GitHub Issue comment
             local issue_number=$(echo "$issue_info" | grep -o '#[0-9]\+' | cut -c2-)
             if [ -n "$issue_number" ]; then
-                echo "  最新のIssueコメント:"
+                echo "  Latest Issue comment:"
                 gh issue view $issue_number --json comments --jq '.comments[-1].body' | head -3
             fi
         else
-            echo "Worker${worker_num}: 利用可能"
+            echo "Worker${worker_num}: Available"
         fi
     done
 }
 ```
 
-### 2. ローカル動作確認（オプション）
+### 2. Local Verification (Optional)
 ```bash
-# ローカル環境での動作確認
+# Local environment verification
 local_verification() {
     local issue_number="$1"
     local branch_name="issue-${issue_number}"
 
-    # local-verification.mdファイルの存在確認
+    # Check existence of local-verification.md file
     if [ ! -f "./local-verification.md" ]; then
-        echo "local-verification.mdが存在しないため、ローカル動作確認をスキップします"
+        echo "local-verification.md does not exist, skipping local verification"
         return 0
     fi
 
-    # ファイルの第一行目がskip:trueの場合
+    # If first line has skip:true
     if head -n 1 "./local-verification.md" | grep -q "<!-- skip:true -->"; then
-        echo "local-verification.mdの第一行目に<!-- skip:true -->が設定されているため、ローカル動作確認をスキップします"
+        echo "<!-- skip:true --> is set in first line of local-verification.md, skipping local verification"
         return 0
     fi
 
-    echo "=== ローカル動作確認開始 ==="
-    echo "チェック項目: local-verification.md に基づいて確認を実施します"
+    echo "=== Local Verification Started ==="
+    echo "Check items: Will perform verification based on local-verification.md"
     echo ""
 
-    # worktreeディレクトリを探してそこに移動
+    # Find worktree directory and move there
     local worktree_dir=$(git worktree list | grep "issue-${issue_number}" | awk '{print $1}')
     if [ -z "$worktree_dir" ]; then
-        echo "❌ Issue #${issue_number}のworktreeディレクトリが見つかりません"
-        echo "Workerがまだ環境セットアップを完了していない可能性があります"
+        echo "❌ worktree directory for Issue #${issue_number} not found"
+        echo "Worker may not have completed environment setup yet"
         return 1
     fi
 
-    echo "📁 Worktreeディレクトリ: $worktree_dir"
+    echo "📁 Worktree directory: $worktree_dir"
     echo ""
-    echo "📋 手順:"
-    echo "1. worktreeディレクトリに移動: cd $worktree_dir"
-    echo "2. local-verification.md の環境セットアップ手順を確認"
-    echo "3. 記載されている手順に従ってサーバーを起動"
-    echo "4. チェック項目に基づいて動作確認を実施"
-    echo "5. 問題がなければ確認完了"
+    echo "📋 Steps:"
+    echo "1. Move to worktree directory: cd $worktree_dir"
+    echo "2. Check environment setup steps in local-verification.md"
+    echo "3. Start server following the listed steps"
+    echo "4. Perform verification based on check items"
+    echo "5. Complete verification if no problems"
     echo ""
-    echo "📄 確認ファイル: local-verification.md"
-    echo "🌐 想定URL: http://localhost:3000 (プロジェクトに応じて変更)"
+    echo "📄 Verification file: local-verification.md"
+    echo "🌐 Expected URL: http://localhost:3000 (change according to project)"
     echo ""
 
-    # worktreeディレクトリに移動
+    # Move to worktree directory
     cd "$worktree_dir"
-    echo "📍 現在の作業ディレクトリ: $(pwd)"
+    echo "📍 Current working directory: $(pwd)"
     echo ""
-    echo "動作確認を開始してください。完了したらEnterを押してください。"
+    echo "Please start verification. Press Enter when completed."
     read -r
 
-    # 元のディレクトリに戻る
+    # Return to original directory
     cd - > /dev/null
 
-    # local-verification.mdの内容を取得
+    # Get contents of local-verification.md
     local checklist_content=$(cat ./local-verification.md)
 
-    # 確認結果をIssueにコメント
-    local verification_comment="## 🔍 ローカル動作確認完了
+    # Comment verification results on Issue
+    local verification_comment="## 🔍 Local Verification Completed
 
-**動作確認日時**: $(date)
-**確認環境**: localhost:3000
-**ブランチ**: ${branch_name}
+**Verification Date/Time**: $(date)
+**Verification Environment**: localhost:3000
+**Branch**: ${branch_name}
 
-### 確認項目
-以下のチェックリストに基づいて確認を実施しました：
+### Check Items
+Verification was performed based on the following checklist:
 
 \`\`\`markdown
 ${checklist_content}
 \`\`\`
 
-### 確認結果
-- ✅ 基本機能: 正常動作
-- ✅ 画面表示: 問題なし
-- ✅ パフォーマンス: 良好
+### Verification Results
+- ✅ Basic functions: Normal operation
+- ✅ Screen display: No problems
+- ✅ Performance: Good
 
-### 次のステップ
-- [ ] マージ承認
-- [ ] 修正依頼
-- [ ] 追加作業
+### Next Steps
+- [ ] Merge approval
+- [ ] Correction request
+- [ ] Additional work
 
 ---
-*Issue Manager による自動確認*"
+*Automatically verified by Issue Manager*"
 
     gh issue comment $issue_number --body "$verification_comment"
 }
 ```
 
-## Issue管理の継続的サイクル
-### 1. 定期的なIssue監視（フィルタ条件対応）
+## Continuous Cycle of Issue Management
+### 1. Regular Issue Monitoring (Filter Condition Support)
 ```bash
-# フィルタ条件に基づくIssue監視
-# 使用例:
-# monitor_issues_with_filter ""                    # 自分にアサインされたIssue（デフォルト）
-# monitor_issues_with_filter "no:assignee"         # 未割り当てIssue
-# monitor_issues_with_filter "no:assignee label:bug"           # bugラベルの未割り当てIssue
-# monitor_issues_with_filter "no:assignee label:enhancement"   # enhancementラベルの未割り当てIssue
-# monitor_issues_with_filter "assignee:@me"        # 自分にアサインされたIssue（明示的指定）
-# monitor_issues_with_filter "no:assignee label:\"help wanted\""   # 未割り当て且つヘルプ募集
+# Issue monitoring based on filter conditions
+# Usage examples:
+# monitor_issues_with_filter ""                    # Issues assigned to me (default)
+# monitor_issues_with_filter "no:assignee"         # Unassigned Issues
+# monitor_issues_with_filter "no:assignee label:bug"           # Unassigned Issues with bug label
+# monitor_issues_with_filter "no:assignee label:enhancement"   # Unassigned Issues with enhancement label
+# monitor_issues_with_filter "assignee:@me"        # Issues assigned to me (explicit specification)
+# monitor_issues_with_filter "no:assignee label:\"help wanted\""   # Unassigned and help wanted
 monitor_issues_with_filter() {
     local filter_condition="$1"
-    echo "=== GitHub Issue監視開始 ==="
+    echo "=== GitHub Issue Monitoring Started ==="
 
-    # フィルタ条件の表示
+    # Display filter condition
     if [ -n "$filter_condition" ]; then
-        echo "フィルタ条件: $filter_condition"
+        echo "Filter condition: $filter_condition"
     else
-        echo "フィルタ条件: なし（自分にアサインされたIssue）"
+        echo "Filter condition: None (Issues assigned to me)"
     fi
 
-    # 一時ファイルのクリーンアップ
+    # Cleanup temporary files
     mkdir -p ./tmp
     rm -f ./tmp/filtered_issues.json
 
-    # フィルタ条件に基づいてIssueを取得
+    # Get Issues based on filter condition
     if [ -n "$filter_condition" ]; then
-        # フィルタ条件ありの場合
+        # With filter condition
         gh issue list --state open --search "$filter_condition" --json number,title,assignees,labels > ./tmp/filtered_issues.json
     else
-        # フィルタ条件なしの場合（デフォルト：自分にアサインされたIssue）
+        # Without filter condition (default: Issues assigned to me)
         gh issue list --state open --search "assignee:@me" --json number,title,assignees,labels > ./tmp/filtered_issues.json
     fi
 
-    # フィルタされたIssueがある場合
+    # If there are filtered Issues
     if [ -s ./tmp/filtered_issues.json ]; then
         local issue_count=$(jq length ./tmp/filtered_issues.json)
-        echo "条件に合致するIssueが ${issue_count}件 見つかりました"
+        echo "Found ${issue_count} Issues matching the conditions"
 
-        # 各Issueを処理
+        # Process each Issue
         jq -r '.[] | "\(.number):\(.title)"' ./tmp/filtered_issues.json | while read -r issue_line; do
             issue_num=$(echo "$issue_line" | cut -d: -f1)
             issue_title=$(echo "$issue_line" | cut -d: -f2-)
 
             echo ""
-            echo "=== Issue #${issue_num} 処理開始 ==="
-            echo "タイトル: ${issue_title}"
+            echo "=== Issue #${issue_num} processing started ==="
+            echo "Title: ${issue_title}"
 
-            # Issue詳細表示
-            echo "--- Issue詳細 ---"
+            # Display Issue details
+            echo "--- Issue Details ---"
             gh issue view $issue_num --json title,body,labels,assignees | jq -r '
                 "Title: " + .title,
                 "Labels: " + (.labels | map(.name) | join(", ")),
-                "Assignees: " + (if .assignees | length > 0 then (.assignees | map(.login) | join(", ")) else "未割り当て" end),
+                "Assignees: " + (if .assignees | length > 0 then (.assignees | map(.login) | join(", ")) else "Unassigned" end),
                 "Body preview: " + (.body | .[0:200] + (if length > 200 then "..." else "" end))
             '
 
-            # TODO: PR存在確認
+            # TODO: Check PR existence
 
-            # 割り当て確認
+            # Assignment confirmation
             echo ""
-            read -p "Issue #${issue_num} を自分にアサインしますか？ (y/N): " -n 1 -r
+            read -p "Assign Issue #${issue_num} to yourself? (y/N): " -n 1 -r
             echo
             if [[ $REPLY =~ ^[Yy]$ ]]; then
                 assign_issue "$issue_num" "$issue_title"
             else
-                echo "Issue #${issue_num} をスキップしました"
+                echo "Skipped Issue #${issue_num}"
             fi
         done
     else
-        echo "条件に合致するIssueはありません"
+        echo "No Issues match the conditions"
     fi
 
-    # 一時ファイルクリーンアップ
+    # Cleanup temporary files
     rm -f ./tmp/filtered_issues.json
 }
 
 
 ```
 
-### 2. Worker負荷バランシング
+### 2. Worker Load Balancing
 ```bash
-# Worker負荷確認（環境セットアップ状況も含む）
+# Check Worker load (including environment setup status)
 check_worker_load() {
-    echo "=== Worker負荷状況 ==="
+    echo "=== Worker Load Status ==="
     for ((worker_num=1; worker_num<=WORKER_COUNT; worker_num++)); do
         if [ -f ./tmp/worker-status/worker${worker_num}_busy.txt ]; then
             local issue_info=$(cat ./tmp/worker-status/worker${worker_num}_busy.txt)
@@ -621,81 +621,81 @@ check_worker_load() {
 
             if [ -f "./tmp/worker-status/worker${worker_num}_setup_success.txt" ]; then
                 local setup_time=$(cat "./tmp/worker-status/worker${worker_num}_setup_success.txt")
-                setup_status=" [環境セットアップ済み: ${setup_time}]"
+                setup_status=" [Environment setup completed: ${setup_time}]"
             else
-                setup_status=" [⚠️ 環境セットアップ未完了]"
+                setup_status=" [⚠️ Environment setup incomplete]"
             fi
 
-            echo "Worker${worker_num}: 作業中 - ${issue_info}${setup_status}"
+            echo "Worker${worker_num}: Working - ${issue_info}${setup_status}"
         else
-            echo "Worker${worker_num}: 利用可能"
+            echo "Worker${worker_num}: Available"
         fi
     done
 }
 
-# Worker環境セットアップ状況の詳細確認
+# Detailed check of Worker environment setup status
 check_worker_environment_status() {
-    echo "=== Worker環境セットアップ状況詳細 ==="
+    echo "=== Worker Environment Setup Status Details ==="
     for ((worker_num=1; worker_num<=WORKER_COUNT; worker_num++)); do
         echo "--- Worker${worker_num} ---"
 
         if [ -f "./tmp/worker-status/worker${worker_num}_busy.txt" ]; then
             local issue_info=$(cat "./tmp/worker-status/worker${worker_num}_busy.txt")
-            echo "割り当て Issue: ${issue_info}"
+            echo "Assigned Issue: ${issue_info}"
 
             if [ -f "./tmp/worker-status/worker${worker_num}_setup_success.txt" ]; then
                 local setup_time=$(cat "./tmp/worker-status/worker${worker_num}_setup_success.txt")
-                echo "環境セットアップ: ✅ 成功 (${setup_time})"
+                echo "Environment Setup: ✅ Success (${setup_time})"
             else
-                echo "環境セットアップ: ❌ 未完了または失敗"
-                echo "⚠️  このWorkerは環境セットアップが完了していません！"
+                echo "Environment Setup: ❌ Incomplete or failed"
+                echo "⚠️  This Worker has not completed environment setup!"
             fi
         else
-            echo "状況: 利用可能（待機中）"
+            echo "Status: Available (standby)"
         fi
         echo ""
     done
 }
 ```
 
-## フィルタ条件を使った実践的な使用例
+## Practical Usage Examples with Filter Conditions
 
-### シナリオ別のフィルタ活用
+### Filter Usage by Scenario
 ```bash
-# 1. 自分の作業進捗を確認したい場合（デフォルト）
+# 1. When you want to check your work progress (default)
 monitor_issues_with_filter ""
 
-# 2. 新しいIssueを探したい場合
+# 2. When you want to find new Issues
 monitor_issues_with_filter "no:assignee"
 
-# 3. 自分のバグ修正タスクを確認したい場合
+# 3. When you want to check your bug fix tasks
 monitor_issues_with_filter "assignee:@me label:bug"
 ```
 
-## 重要なポイント
-- 各Workerが同時に1つのIssueのみ処理するよう厳密管理
-- GitHub IssueとPRの状況を常に把握
-- **Worker環境セットアップの強制実行と失敗時の安全な回復**
-- **環境セットアップなしでのIssue割り当てを完全防止**
-- 進捗の可視化と適切なフィードバック
-- 品質確保のためのローカル確認プロセス
-- 継続的なIssue監視と効率的な割り当て
-- **フィルタ条件を活用した効率的なIssue管理**
+## Important Points
+- Strict management so each Worker processes only one Issue at a time
+- Always understand GitHub Issue and PR status
+- **Mandatory execution of Worker environment setup and safe recovery on failure**
+- **Complete prevention of Issue assignment without environment setup**
+- Progress visualization and appropriate feedback
+- Local verification process for quality assurance
+- Continuous Issue monitoring and efficient assignment
+- **Efficient Issue management using filter conditions**
 
-## 使用ガイドライン
+## Usage Guidelines
 
-### Issue割り当て時の推奨手順
-1. **必須**: `assign_issue()` を使用
-2. **推奨**: 割り当て前に `check_worker_load()` でWorker状況を確認
-3. **推奨**: 定期的に `check_worker_environment_status()` で環境セットアップ状況を確認
+### Recommended Steps for Issue Assignment
+1. **Mandatory**: Use `assign_issue()`
+2. **Recommended**: Check Worker status with `check_worker_load()` before assignment
+3. **Recommended**: Regularly check environment setup status with `check_worker_environment_status()`
 
-### 環境セットアップ失敗時の対応
-1. エラーメッセージを確認し、原因を特定
-2. Workerの tmux セッション状況を確認
-3. 必要に応じて手動でセットアップ手順を実行
-4. 問題が解決したら再度 `assign_issue()` を実行
+### Response to Environment Setup Failures
+1. Check error messages and identify the cause
+2. Check Worker's tmux session status
+3. Manually execute setup steps as needed
+4. Execute `assign_issue()` again once the problem is resolved
 
-### 安全性確保のためのチェックポイント
-- ✅ Worker環境セットアップが完了していることを確認
-- ✅ GitHub Issue Assignmentとworktree環境が一致していることを確認
-- ✅ 失敗時にクリーンアップが適切に実行されていることを確認
+### Safety Checkpoints
+- ✅ Confirm Worker environment setup is completed
+- ✅ Confirm GitHub Issue Assignment and worktree environment match
+- ✅ Confirm cleanup is properly executed on failure

--- a/claude/instructions/worker.md
+++ b/claude/instructions/worker.md
@@ -49,152 +49,152 @@ As a developer specializing in GitHub Issue resolution, efficiently execute task
 - Impact on users
 - Technical necessity
 
-### HOW（どう実装するか）
-- 技術的アプローチ
-- 使用するライブラリ・フレームワーク
-- 実装手順
+### HOW (How to implement)
+- Technical approach
+- Libraries and frameworks to use
+- Implementation procedures
 
-### ACCEPTANCE CRITERIA（受け入れ基準）
-- 完了条件
-- テスト要件
-- 品質基準
+### ACCEPTANCE CRITERIA (Acceptance criteria)
+- Completion conditions
+- Test requirements
+- Quality standards
 ```
 
-### 2. Issue解決タスクリストテンプレート
+### 2. Issue Resolution Task List Template
 ```markdown
-## Issue #[NUMBER] 解決タスク
+## Issue #[NUMBER] Resolution Tasks
 
-### 【環境確認フェーズ】
-- [ ] 現在のworktree環境確認 (issue-[NUMBER])
-- [ ] ブランチとディレクトリ状態確認
-- [ ] 依存関係インストール確認
-- [ ] Issue詳細確認とAcceptance Criteria理解
+### 【Environment Verification Phase】
+- [ ] Verify current worktree environment (issue-[NUMBER])
+- [ ] Check branch and directory status
+- [ ] Verify dependency installation
+- [ ] Confirm Issue details and understand Acceptance Criteria
 
-### 【実装フェーズ】
-- [ ] 技術調査と設計
-- [ ] コア機能実装
-- [ ] エラーハンドリング
-- [ ] テストケース作成
+### 【Implementation Phase】
+- [ ] Technical research and design
+- [ ] Core functionality implementation
+- [ ] Error handling
+- [ ] Test case creation
 
-### 【品質確保フェーズ】
-- [ ] 単体テスト実行
-- [ ] 統合テスト実行
-- [ ] コードレビュー
-- [ ] パフォーマンス確認
+### 【Quality Assurance Phase】
+- [ ] Execute unit tests
+- [ ] Execute integration tests
+- [ ] Code review
+- [ ] Performance verification
 
-### 【完了フェーズ】
-- [ ] Pull Request作成
-- [ ] Issue進捗コメント
-- [ ] Issue Manager報告
+### 【Completion Phase】
+- [ ] Create Pull Request
+- [ ] Add Issue progress comments
+- [ ] Report to Issue Manager
 ```
 
-## GitHub Issue解決の実装手法
-### 1. 環境セットアップコマンド
+## GitHub Issue Resolution Implementation Methods
+### 1. Environment Setup Commands
 ```bash
-# Issue解決用の作業環境確認（既にworktree環境で起動済み）
+# Verify work environment for Issue resolution (already started in worktree environment)
 verify_issue_environment() {
     local issue_number="$1"
 
-    echo "=== Issue #${issue_number} 環境確認開始 ==="
+    echo "=== Issue #${issue_number} environment verification started ==="
 
-    # 1. 現在のディレクトリと作業環境を確認
-    echo "現在のディレクトリ: $(pwd)"
-    echo "現在のブランチ: $(git branch --show-current)"
-    echo "作業ツリーの状態:"
+    # 1. Check current directory and work environment
+    echo "Current directory: $(pwd)"
+    echo "Current branch: $(git branch --show-current)"
+    echo "Working tree status:"
     git status --short
 
-    # 2. worktree環境であることを確認
+    # 2. Verify that this is a worktree environment
     local current_dir=$(pwd)
     if [[ $current_dir == *"worktree/issue-${issue_number}"* ]]; then
-        echo "✅ 正しいworktree環境で動作中です"
+        echo "✅ Operating in correct worktree environment"
 
-        # 追加の安全性チェック
+        # Additional safety checks
         local git_dir=$(git rev-parse --git-dir)
         if [[ $git_dir == *".git/worktrees/"* ]]; then
-            echo "✅ worktreeが正しく分離されています: $git_dir"
+            echo "✅ Worktree is properly isolated: $git_dir"
         else
-            echo "❌ 危険: worktreeが適切に分離されていません"
-            echo "作業を停止し、Issue Managerに報告してください"
+            echo "❌ Danger: Worktree is not properly isolated"
+            echo "Stop work and report to Issue Manager"
             return 1
         fi
 
-        # mainブランチでないことを確認
+        # Verify not on main branch
         local current_branch=$(git branch --show-current)
         if [ "$current_branch" = "main" ]; then
-            echo "❌ 危険: mainブランチで作業しようとしています"
-            echo "作業を停止し、Issue Managerに報告してください"
+            echo "❌ Danger: Attempting to work on main branch"
+            echo "Stop work and report to Issue Manager"
             return 1
         fi
 
-        echo "✅ 現在のブランチ: $current_branch"
+        echo "✅ Current branch: $current_branch"
     else
-        echo "❌ 危険: 期待されるworktree環境ではありません"
-        echo "期待されるパス: */worktree/issue-${issue_number}"
-        echo "現在のパス: $current_dir"
-        echo "作業を停止し、Issue Managerに報告してください"
+        echo "❌ Danger: Not in expected worktree environment"
+        echo "Expected path: */worktree/issue-${issue_number}"
+        echo "Current path: $current_dir"
+        echo "Stop work and report to Issue Manager"
         return 1
     fi
 
-    # 2. 依存関係インストール（設定可能なスクリプトを実行）
+    # 2. Install dependencies (execute configurable script)
     ./claude/setup_environment_command.sh
 
-    # 3. Issue詳細確認
-    echo "=== Issue詳細 ==="
+    # 3. Check Issue details
+    echo "=== Issue Details ==="
     gh issue view ${issue_number}
 
-    echo "=== 環境確認完了 ==="
+    echo "=== Environment verification completed ==="
 }
 ```
 
-### 2. Issue進捗報告とコメント
+### 2. Issue Progress Reporting and Comments
 ```bash
-# GitHub Issueへの進捗コメント
+# Progress comments to GitHub Issue
 update_issue_progress() {
     local issue_number="$1"
     local status="$2"
     local details="$3"
 
-    local comment="## 🔄 進捗報告 - $(date '+%Y-%m-%d %H:%M')
+    local comment="## 🔄 Progress Report - $(date '+%Y-%m-%d %H:%M')
 
-**ステータス**: ${status}
+**Status**: ${status}
 
-**実施内容**:
+**Implementation Details**:
 ${details}
 
-**次のステップ**:
-- [予定している次の作業]
+**Next Steps**:
+- [Planned next work]
 
 ---
-*Worker${WORKER_NUM} による自動更新*"
+*Automatic update by Worker${WORKER_NUM}*"
 
     gh issue comment ${issue_number} --body "$comment"
 }
 
-# Issue Manager への問題報告
+# Problem reporting to Issue Manager
 report_to_manager() {
     local issue_number="$1"
     local problem="$2"
 
-    ./claude/agent-send.sh issue-manager "【Issue #${issue_number} 課題報告】Worker${WORKER_NUM}
+    ./claude/agent-send.sh issue-manager "【Issue #${issue_number} Problem Report】Worker${WORKER_NUM}
 
-    ## 発生した問題
+    ## Problem Occurred
     ${problem}
 
-    ## 現在の状況
-    - 実装進捗: [X%]
-    - 影響範囲: [説明]
+    ## Current Status
+    - Implementation progress: [X%]
+    - Impact scope: [description]
 
-    ## 対応方針
-    - [提案する解決策]
+    ## Response Plan
+    - [Proposed solution]
 
-    アドバイスをお願いします。"
+    Please provide advice."
 }
 ```
 
-## Pull Request作成と完了報告
-### 1. Pull Request作成
+## Pull Request Creation and Completion Report
+### 1. Pull Request Creation
 ```bash
-# PR作成とIssue完了処理
+# PR creation and Issue completion processing
 create_pr_and_complete() {
     local issue_number="$1"
     local pr_title="$2"

--- a/claude/setup.sh
+++ b/claude/setup.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 
-# 🚀 GitHub Issue Management System 環境構築
+# 🚀 GitHub Issue Management System Environment Setup
 
-set -e  # エラー時に停止
+set -e  # Stop on error
 
-# ヘルプオプション処理
+# Help option handling
 if [[ "$1" == "--help" || "$1" == "-h" ]]; then
     echo "🤖 GitHub Issue Management System Environment Setup"
     echo "============================================="
@@ -59,94 +59,94 @@ log_success() {
     echo -e "\033[1;34m[SUCCESS]\033[0m $1"
 }
 
-echo "🤖 GitHub Issue Management System 環境構築"
+echo "🤖 GitHub Issue Management System Environment Setup"
 echo "============================================="
-echo "📊 設定: Worker数 = $WORKER_COUNT"
-echo "🔧 Claude引数設定:"
-echo "   Issue Manager: ${ISSUE_MANAGER_ARGS:-"(引数なし)"}"
-echo "   Workers: ${WORKER_ARGS:-"(引数なし)"}"
+echo "📊 Configuration: Worker count = $WORKER_COUNT"
+echo "🔧 Claude arguments configuration:"
+echo "   Issue Manager: ${ISSUE_MANAGER_ARGS:-"(no arguments)"}"
+echo "   Workers: ${WORKER_ARGS:-"(no arguments)"}"
 echo ""
 
-# STEP 1: 既存セッションクリーンアップ
-log_info "🧹 既存セッションクリーンアップ開始..."
+# STEP 1: Cleanup existing sessions
+log_info "🧹 Starting cleanup of existing sessions..."
 
-tmux kill-session -t multiagent 2>/dev/null && log_info "multiagentセッション削除完了" || log_info "multiagentセッションは存在しませんでした"
+tmux kill-session -t multiagent 2>/dev/null && log_info "multiagent session deletion completed" || log_info "multiagent session did not exist"
 
-# 完了ファイルクリア
+# Clear completion files
 mkdir -p ./tmp/worker-status
-rm -f ./tmp/worker*_done.txt 2>/dev/null && log_info "既存の完了ファイルをクリア" || log_info "完了ファイルは存在しませんでした"
-rm -f ./tmp/worker-status/worker*_busy.txt 2>/dev/null && log_info "既存のWorker状況ファイルをクリア" || log_info "Worker状況ファイルは存在しませんでした"
+rm -f ./tmp/worker*_done.txt 2>/dev/null && log_info "Cleared existing completion files" || log_info "Completion files did not exist"
+rm -f ./tmp/worker-status/worker*_busy.txt 2>/dev/null && log_info "Cleared existing worker status files" || log_info "Worker status files did not exist"
 
-# .gitignoreにworktreeエントリを追加
-log_info ".gitignoreにworktreeエントリを追加中..."
+# Add worktree entry to .gitignore
+log_info "Adding worktree entry to .gitignore..."
 if [ ! -f ".gitignore" ]; then
     touch .gitignore
-    log_info ".gitignoreファイルを作成しました"
+    log_info ".gitignore file created"
 fi
 
 if ! grep -q "^worktree/$" .gitignore; then
     echo "worktree/" >> .gitignore
-    log_info ".gitignoreにworktree/を追加しました"
+    log_info "Added worktree/ to .gitignore"
 else
-    log_info ".gitignoreに既にworktree/が存在します"
+    log_info "worktree/ already exists in .gitignore"
 fi
 
-# worktreeクリーンアップ実行
-log_info "🧹 worktreeクリーンアップ実行中..."
+# Execute worktree cleanup
+log_info "🧹 Executing worktree cleanup..."
 if [ -f "./claude/cleanup-worktrees.sh" ]; then
     ./claude/cleanup-worktrees.sh
-    log_info "✅ worktreeクリーンアップ完了"
+    log_info "✅ Worktree cleanup completed"
 else
-    log_info "⚠️  cleanup-worktrees.sh が見つかりません (スキップ)"
+    log_info "⚠️  cleanup-worktrees.sh not found (skipping)"
 fi
 
-# worktreeディレクトリの準備
+# Prepare worktree directory
 mkdir -p worktree
-log_info "worktreeディレクトリを作成しました"
+log_info "Worktree directory created"
 
-log_success "✅ クリーンアップ完了"
+log_success "✅ Cleanup completed"
 echo ""
 
-# STEP 2: multiagentセッション作成（動的ペイン数：issue-manager + workers）
+# STEP 2: Create multiagent session (dynamic pane count: issue-manager + workers)
 TOTAL_PANES=$((WORKER_COUNT + 1))
-log_info "📺 multiagentセッション作成開始 (${TOTAL_PANES}ペイン: issue-manager + ${WORKER_COUNT}workers)..."
+log_info "📺 Starting multiagent session creation (${TOTAL_PANES} panes: issue-manager + ${WORKER_COUNT} workers)..."
 
-# 最初のペイン作成
+# Create first pane
 tmux new-session -d -s multiagent -n "agents"
 
-# 動的なペイン分割（ワーカー数に応じて）
+# Dynamic pane splitting (based on worker count)
 if [ "$WORKER_COUNT" -eq 1 ]; then
-    # 1 worker: 左右分割
+    # 1 worker: horizontal split
     tmux split-window -h -t "multiagent:0"
 elif [ "$WORKER_COUNT" -eq 2 ]; then
-    # 2 workers: 上下分割後、右側を左右分割
+    # 2 workers: horizontal split then vertical split on right
     tmux split-window -h -t "multiagent:0"
     tmux select-pane -t "multiagent:0.1"
     tmux split-window -v
 elif [ "$WORKER_COUNT" -eq 3 ]; then
-    # 3 workers: 2x2グリッド
+    # 3 workers: 2x2 grid
     tmux split-window -h -t "multiagent:0"
     tmux select-pane -t "multiagent:0.0"
     tmux split-window -v
     tmux select-pane -t "multiagent:0.2"
     tmux split-window -v
 else
-    # 4+ workers: 左右分割後、両側を縦分割
+    # 4+ workers: horizontal split then vertical splits on both sides
     tmux split-window -h -t "multiagent:0"
 
-    # 左側を縦分割（issue-manager + 最初のworker）
+    # Vertical split on left (issue-manager + first worker)
     tmux select-pane -t "multiagent:0.0"
     tmux split-window -v
 
-    # 右側を縦分割（残りのworkers）
+    # Vertical splits on right (remaining workers)
     tmux select-pane -t "multiagent:0.2"
     for ((i=3; i<=WORKER_COUNT; i++)); do
         tmux split-window -v
     done
 fi
 
-# ペインタイトル設定
-log_info "ペインタイトル設定中..."
+# Set pane titles
+log_info "Setting pane titles..."
 
 # issue-manager
 tmux select-pane -t "multiagent:0.0" -T "issue-manager"
@@ -156,85 +156,85 @@ for ((i=1; i<=WORKER_COUNT; i++)); do
     tmux select-pane -t "multiagent:0.$i" -T "worker$i"
 done
 
-# 各ペインの初期設定
+# Initial setup for each pane
 for ((i=0; i<=WORKER_COUNT; i++)); do
-    # 作業ディレクトリ設定
+    # Set working directory
     tmux send-keys -t "multiagent:0.$i" "cd $(pwd)" C-m
 
-    # Claude引数環境変数を各ペインに設定
+    # Set Claude argument environment variables for each pane
     tmux send-keys -t "multiagent:0.$i" "export ISSUE_MANAGER_ARGS='${ISSUE_MANAGER_ARGS}'" C-m
     tmux send-keys -t "multiagent:0.$i" "export WORKER_ARGS='${WORKER_ARGS}'" C-m
 
-    # ペインタイトル取得
+    # Get pane title
     if [ $i -eq 0 ]; then
         PANE_TITLE="issue-manager"
-        # issue-manager: 緑色
+        # issue-manager: green color
         tmux send-keys -t "multiagent:0.$i" "export PS1='(\[\033[1;32m\]${PANE_TITLE}\[\033[0m\]) \[\033[1;32m\]\w\[\033[0m\]\$ '" C-m
     else
         PANE_TITLE="worker$i"
-        # workers: 青色
+        # workers: blue color
         tmux send-keys -t "multiagent:0.$i" "export PS1='(\[\033[1;34m\]${PANE_TITLE}\[\033[0m\]) \[\033[1;32m\]\w\[\033[0m\]\$ '" C-m
     fi
 
-    # ウェルカムメッセージ
-    tmux send-keys -t "multiagent:0.$i" "echo '=== ${PANE_TITLE} エージェント ==='" C-m
+    # Welcome message
+    tmux send-keys -t "multiagent:0.$i" "echo '=== ${PANE_TITLE} agent ==='" C-m
 done
 
-# Claude Code起動（issue-managerのみ）
-log_info "🤖 issue-manager用Claude Code起動中..."
+# Start Claude Code (issue-manager only)
+log_info "🤖 Starting Claude Code for issue-manager..."
 tmux send-keys -t "multiagent:0.0" "claude ${ISSUE_MANAGER_ARGS}" C-m
 
-# workers用の待機メッセージ
+# Standby messages for workers
 for ((i=1; i<=WORKER_COUNT; i++)); do
-    tmux send-keys -t "multiagent:0.$i" "echo '=== worker$i 待機中 ==='" C-m
-    tmux send-keys -t "multiagent:0.$i" "echo 'Issue Managerからの割り当てをお待ちください'" C-m
-    tmux send-keys -t "multiagent:0.$i" "echo 'Claudeは割り当て時に自動起動されます'" C-m
+    tmux send-keys -t "multiagent:0.$i" "echo '=== worker$i waiting ==='" C-m
+    tmux send-keys -t "multiagent:0.$i" "echo 'Please wait for assignment from Issue Manager'" C-m
+    tmux send-keys -t "multiagent:0.$i" "echo 'Claude will be started automatically when assigned'" C-m
 done
 
-# Claude起動の待機時間
+# Wait time for Claude startup
 sleep 3
 
-log_success "✅ issue-manager用Claude Codeの起動完了"
-log_success "✅ multiagentセッション作成完了"
+log_success "✅ Claude Code startup for issue-manager completed"
+log_success "✅ multiagent session creation completed"
 echo ""
 
-# STEP 3: 環境確認・表示
-log_info "🔍 環境確認中..."
+# STEP 3: Environment verification and display
+log_info "🔍 Verifying environment..."
 
 echo ""
-echo "📊 セットアップ結果:"
+echo "📊 Setup Results:"
 echo "==================="
 
-# tmuxセッション確認
+# Check tmux sessions
 echo "📺 Tmux Sessions:"
 tmux list-sessions
 echo ""
 
-# ペイン構成表示
-echo "📋 ペイン構成:"
-echo "  multiagentセッション（${TOTAL_PANES}ペイン）:"
-echo "    Pane 0: issue-manager (GitHub Issue管理者)"
+# Display pane configuration
+echo "📋 Pane Configuration:"
+echo "  multiagent session (${TOTAL_PANES} panes):"
+echo "    Pane 0: issue-manager (GitHub Issue Manager)"
 for ((i=1; i<=WORKER_COUNT; i++)); do
-    echo "    Pane $i: worker$i       (Issue解決担当者#$i)"
+    echo "    Pane $i: worker$i       (Issue Resolution Worker #$i)"
 done
 
 echo ""
-log_success "🎉 GitHub Issue管理システム環境セットアップ完了！"
+log_success "🎉 GitHub Issue Management System environment setup completed!"
 echo ""
-echo "📋 次のステップ:"
-echo "  1. 🔗 セッションアタッチ:"
-echo "     tmux attach-session -t multiagent   # GitHub Issue管理システム確認"
-echo "     ※ Claude Codeはissue-managerペインでのみ起動済みです"
-echo "     ※ worker用Claudeは、Issue割り当て時に自動起動されます"
+echo "📋 Next Steps:"
+echo "  1. 🔗 Attach to session:"
+echo "     tmux attach-session -t multiagent   # Check GitHub Issue Management System"
+echo "     ※ Claude Code is started only in the issue-manager pane"
+echo "     ※ Worker Claude will be started automatically when issues are assigned"
 echo ""
-echo "  2. 📜 指示書確認:"
+echo "  2. 📜 Check instructions:"
 echo "     Issue Manager: instructions/issue-manager.md"
 echo "     worker1-${WORKER_COUNT}: instructions/worker.md"
-echo "     システム構造: CLAUDE.md"
+echo "     System structure: CLAUDE.md"
 echo ""
-echo "  3. 🎯 システム起動: Issue Managerに以下のメッセージを入力:"
-echo "     「あなたはissue-managerです。指示書に従ってGitHub Issueの監視を開始してください」"
+echo "  3. 🎯 Start system: Enter the following message to Issue Manager:"
+echo "     \"You are the issue-manager. Please start monitoring GitHub Issues according to the instructions\""
 echo ""
-echo "  4. 📋 GitHub設定確認:"
-echo "     gh auth status  # GitHub CLI認証確認"
-echo "     gh repo view     # リポジトリ確認"
+echo "  4. 📋 Check GitHub configuration:"
+echo "     gh auth status  # Check GitHub CLI authentication"
+echo "     gh repo view     # Check repository"

--- a/install.sh
+++ b/install.sh
@@ -169,20 +169,20 @@ get_claude_content() {
 
 # GitHub Issue Management System
 
-## エージェント構成
-- **issue-manager** (multiagent:0.0): GitHub Issue管理者
-- **worker1-N** (multiagent:0.1-N): Issue解決担当（Nはsetup.shで指定、デフォルト3）
+## Agent Configuration
+- **issue-manager** (multiagent:0.0): GitHub Issue Manager
+- **worker1-N** (multiagent:0.1-N): Issue Resolution Workers (N specified in setup.sh, default 3)
 
-## あなたの役割
+## Your Role
 - **issue-manager**: @claude/instructions/issue-manager.md
 - **worker1-N**: @claude/instructions/worker.md
 
-## メッセージ送信
+## Message Sending
 ```bash
-./claude/agent-send.sh [相手] "[メッセージ]"
+./claude/agent-send.sh [recipient] "[message]"
 ```
 
-## 基本フロー
+## Basic Flow
 GitHub Issues → issue-manager → workers → issue-manager → GitHub PRs
 EOF
 }
@@ -275,7 +275,7 @@ show_post_install_instructions() {
     echo "   claude"
     echo ""
     echo "4. 📊 Begin GitHub Issue management:"
-    echo "   あなたはissue-managerです。指示書に従ってGitHub Issueの監視を開始してください。"
+    echo "   You are the issue-manager. Please start monitoring GitHub Issues according to the instructions."
     echo ""
     echo "✨ The system is ready to use!"
 }


### PR DESCRIPTION
## Summary
Successfully translated all Japanese text in the repository to English across scripts and documentation files as requested in Issue #1.

## Changes Made
- **README_ja.md**: Complete English translation (679 lines) - transformed from Japanese documentation to comprehensive English guide
- **README.md**: Translated remaining Japanese text snippets to maintain consistency
- **install.sh**: Translated configuration messages, prompts, and user instructions
- **claude/setup.sh**: Translated all log messages, status updates, and user interface text
- **claude/agent-send.sh**: Translated help text, status messages, and error messages
- **claude/instructions/issue-manager.md**: Complete translation of issue manager instructions and shell script comments
- **claude/instructions/worker.md**: Translated Japanese sections, templates, and code comments

## Quality Assurance
- ✅ All shell scripts execute correctly with English output
- ✅ Help messages display properly in English  
- ✅ System functionality fully preserved
- ✅ Technical commands and syntax maintained
- ✅ Markdown formatting and structure preserved

## Technical Details
- Preserved all shell script functionality and command syntax
- Maintained technical variable names and function calls intact
- Translated user-facing messages, comments, and documentation
- Kept code structure and formatting consistent

## Test Results
- Setup script help: ✅ Displays in English
- Agent communication: ✅ Shows English interface
- All functionality verified working

The repository is now fully accessible to English-speaking developers while maintaining all original functionality.

Closes #1